### PR TITLE
Intersecting Building Check Enhancments Review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 **/out/
 /bin/
 **/ignored/
+/data/*.pbf

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ To run Atlas Checks the following is required:
 To start working with Checks follow the steps below:
 1. Clone Atlas Checks project using following command `git clone https://github.com/osmlab/atlas-checks.git`
 2. Switch to newly created directory: `cd atlas-checks`
-3. Execute `gradle run`
+3. Download an OSM PBF file and place it in the `/data/` directory.
+3. Execute `./gradlew run`
 
-This command will build and run Atlas Checks with all the default options against the country Anguilla. GeoJSON output will be be produced that contains all the results found from the run. For more information on running Atlas Checks as a standalone application click [here](docs/standalone.md).
+This command will build and run Atlas Checks with all the default options against OSM PBF that you put in the data directory.. GeoJSON output will be be produced that contains all the results found from the run. Those outputs will be found in `/build/geojson/`. For more information on running Atlas Checks as a standalone application click [here](docs/standalone.md).
 
 ## Working with Configuration
 See [configuration docs](docs/configuration.md) for more information about the configuration files that can be used to define specific details around the Atlas Checks application.

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -255,5 +255,22 @@
       "defaultPriority": "MEDIUM"
     },
     "tags":"highway"
+  },
+  "WaterbodyAndIslandSizeCheck": {
+    "surface":{
+      "waterbody.minimum.meters": 10.0,
+      "waterbody.maximum.kilometers": 370000.0,
+      "island.minimum.meters": 10.0,
+      "island.maximum.kilometers": 2170000.0,
+      "islet.minimum.meters": 10.0,
+      "islet.maximum.kilometers": 1.0
+    },
+    "challenge": {
+      "description": "This tasks contains waterboadies and islands which are either too small or too large in size.",
+      "blurb": "Waterbodies and Islands that are too large, or too small",
+      "instruction": "Open your favorite editor and examine if the waterbody or island is correctly tagged and mapped.",
+      "difficulty": "NORMAL",
+      "defaultPriority": "MEDIUM"
+    }
   }
 }

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -128,7 +128,6 @@
     }
   },
   "MalformedRoundaboutCheck" : {
-    "enabled": false,
     "traffic.countries.left":["AIA", "ATG", "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN", "BWA",
       "CCK", "COK", "CXR", "CYM", "CYP", "DMA", "FJI", "FLK", "GBR", "GGY", "GRD",
       "GUY", "HKG", "IDN", "IMN", "IND", "IRL", "JAM", "JEY", "JPN", "KEN", "KIR",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -107,6 +107,17 @@
       "tags":"highway"
     }
   },
+  "IntersectingBuildingCheck":
+  {
+    "intersection.lower.limit": 0.01,
+    "challenge": {
+      "description": "Buildings that intersect, contain, or overlap each other.",
+      "blurb": "Intersecting Buildings",
+      "instruction": "Correct intersecting buildings by moving them or dissolving one into another.",
+      "difficulty": "NORMAL",
+      "tags":"building"
+    }
+  },
   "InvalidTurnRestrictionCheck": {
     "challenge": {
       "description": "Tasks containing invalid turn restrictions",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -116,6 +116,21 @@
       "tags":"highway"
     }
   },
+  "MalformedRoundaboutCheck" : {
+    "traffic.countries.left":["AIA", "ATG", "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN", "BWA",
+      "CCK", "COK", "CXR", "CYM", "CYP", "DMA", "FJI", "FLK", "GBR", "GGY", "GRD",
+      "GUY", "HKG", "IDN", "IMN", "IND", "IRL", "JAM", "JEY", "JPN", "KEN", "KIR",
+      "KNA", "LCA", "LKA", "LSO", "MAC", "MDV", "MLT", "MOZ", "MSR", "MUS", "MWI",
+      "MYS", "NAM", "NFK", "NIU", "NPL", "NRU", "NZL", "PAK", "PCN", "PNG", "SGP",
+      "SGS", "SHN", "SLB", "SUR", "SWZ", "SYC", "TCA", "THA", "TKL", "TLS", "TON",
+      "TTO", "TUV", "TZA", "UGA", "VCT", "VGB", "VIR", "WSM", "ZAF", "ZMB", "ZWE"],
+    "challenge": {
+      "description": "Tasks contain roundabouts that are malformed.",
+      "blurb": "Malformed roundabouts",
+      "instruction": "Open your favorite editor and fix the roundabout's geometry.",
+      "difficulty": "MEDIUM"
+    }
+  },
   "OneMemberRelationCheck": {
     "challenge": {
       "description": "Tasks containing relations with only one member.",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -117,6 +117,7 @@
     }
   },
   "MalformedRoundaboutCheck" : {
+    "enabled": false,
     "traffic.countries.left":["AIA", "ATG", "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN", "BWA",
       "CCK", "COK", "CXR", "CYM", "CYP", "DMA", "FJI", "FLK", "GBR", "GGY", "GRD",
       "GUY", "HKG", "IDN", "IMN", "IND", "IRL", "JAM", "JEY", "JPN", "KEN", "KIR",

--- a/docs/checks/malformedRoundaboutCheck.md
+++ b/docs/checks/malformedRoundaboutCheck.md
@@ -1,0 +1,220 @@
+# Malformed Roundabout Check
+
+#### Description
+This check flags roundabouts where:
+1. the directionality is opposite to what it should be (for example, a counterclockwise roundabout in a right-driving country), where
+2. the segments are  multi-directional, or
+3. the incorrect geometry (concave)
+
+#### Live Example
+1) This roundabout [id:242413354](https://www.openstreetmap.org/way/242413354) is multi-directional and
+has some segment going the wrong way. This is incorrect and should be flagged.
+
+#### Code Review
+
+In [Atlas](https://github.com/osmlab/atlas), OSM elements are represented as Edges, Points, Lines, 
+Nodes & Relations; in our case, we’re working with [Edges](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java).
+In OpenStreetMap, roundabouts are [Ways](https://wiki.openstreetmap.org/wiki/Way) classified with
+the `junction=roundabout` tag. We’ll use this information to filter our potential flag candidates.
+
+Our first goal is to validate the incoming Atlas Object. We know two things about roundabouts:
+* Must be a valid Edge
+* Must have an `iso_country_code` tag
+* Must have not already been flagged
+* Must have `junction=roundabout` tag
+* Must not be two way
+* Must be master edge
+
+```java
+      @Override
+         public boolean validCheckForObject(final AtlasObject object)
+         {
+             // We check that the object is an instance of Edge
+             return object instanceof Edge
+                     // Make sure that the object has an iso_country_code
+                     && object.getTag(ISOCountryTag.KEY).isPresent()
+                     // Make sure that the edges are instances of roundabout
+                     && JunctionTag.isRoundabout(object)
+                     // Is not two-way
+                     && !OneWayTag.isExplicitlyTwoWay(object)
+                     // And that the Edge has not already been marked as flagged
+                     && !this.isFlagged(object.getIdentifier())
+                     // Make sure that we are only looking at master edges
+                     && ((Edge) object).isMasterEdge();
+         }
+```
+
+After the preliminary filtering of features, we need to get all the roundabout's edges in sorted
+order because the order of the edges in a roundabout dictate the directionality.
+
+Using the [`connectedEdges()`](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java#L55)
+function, we loop through each Edge's connected Edges until each have been either marked as flagged,
+or added to our roundAboutEdges Set.
+
+```java
+    private List<Edge> getAllRoundaboutEdges(final Edge edge)
+        {
+            final List<Edge> roundaboutEdges = new ArrayList<>();
+    
+            // Initialize a queue to add yet to be processed connected edges to
+            final Queue<Edge> queue = new LinkedList<>();
+    
+            // Mark the current Edge as visited and enqueue it
+            this.markAsFlagged(edge.getIdentifier());
+            queue.add(edge);
+    
+            // As long as the queue is not empty
+            while (!queue.isEmpty())
+            {
+                // Dequeue a connected edge and add it to the roundaboutEdges
+                final Edge currentEdge = queue.poll();
+    
+                roundaboutEdges.add(currentEdge);
+    
+                // Get the edges connected to the edge e as an iterator
+                final Set<Edge> connectedEdges = currentEdge.connectedEdges();
+    
+                for (final Edge connectedEdge : connectedEdges)
+                {
+                    final Long edgeId = connectedEdge.getIdentifier();
+    
+                    if (JunctionTag.isRoundabout(connectedEdge)
+                            && !roundaboutEdges.contains(connectedEdge))
+    
+                    {
+                        this.markAsFlagged(edgeId);
+                        queue.add(connectedEdge);
+                    }
+                }
+            }
+            roundaboutEdges.sort(Edge::compareTo);
+            return roundaboutEdges;
+        }
+```
+
+Once we have all the roundabout's edges in ascending identifier order, we can get the direction. To
+find the direction of the roundabout, we get the cross product of every set of adjacent edges in the
+roundabout. Using the cross product and the [right-hand rule](https://en.wikipedia.org/wiki/Right-hand_rule),
+we get the vector which is orthogonal to each pair of adjacent vectors. 
+```java
+    private static Double getCrossProduct(final Edge edge1, final Edge edge2)
+        {
+    
+            // Get the nodes' latitudes and longitudes to use in deriving the vectors
+            final double node1Y = edge1.start().getLocation().getLatitude().asDegrees();
+            final double node1X = edge1.start().getLocation().getLongitude().asDegrees();
+            final double node2Y = edge1.end().getLocation().getLatitude().asDegrees();
+            final double node2X = edge1.end().getLocation().getLongitude().asDegrees();
+            final double node3Y = edge2.end().getLocation().getLatitude().asDegrees();
+            final double node3X = edge2.end().getLocation().getLongitude().asDegrees();
+    
+            // Get the vectors from node 2 to 1, and node 2 to 3
+            final double vector1X = node2X - node1X;
+            final double vector1Y = node2Y - node1Y;
+            final double vector2X = node2X - node3X;
+            final double vector2Y = node2Y - node3Y;
+    
+            // The cross product tells us the direction of the orthogonal vector, which is
+            // Directly related to the direction of rotation/traffic
+            return (vector1X * vector2Y) - (vector1Y * vector2X);
+        }
+```
+
+A positive cross product carried over all edge pairs indicates that the roundabout is going clockwise, and a negative cross-product carried over all edge pairs
+indicates that the roundabout is going counterclockwise. However, because we are comparing the directionality
+over all edge pairs, we are also able to check for a multi-directional roundabout (meaning that there are
+both clockwise and counterclockwise segments). We return a RoundaboutDirection enum from this
+findRoundaboutDirection method and handle it in the flag method.
+
+```java
+    private static RoundaboutDirection findRoundaboutDirection (final List<Edge> roundaboutEdges)
+        {
+            // Initialize the directionSoFar to UNKNOWN as we have no directional information yet
+            RoundaboutDirection directionSoFar = RoundaboutDirection.UNKNOWN;
+    
+            for (int i = 0; i < roundaboutEdges.size(); i++) {
+                // Get the Edges to use in the cross product
+                final Edge edge1 = roundaboutEdges.get(i);
+                // We mod the roundabout edges here so that we can get the last pair of edges in the
+                // Roundabout correctly
+                final Edge edge2 = roundaboutEdges.get((i + 1) % roundaboutEdges.size());
+    
+                // Get the cross product and then the direction of the roundabout
+                double crossProduct = getCrossProduct(edge1, edge2);
+                RoundaboutDirection direction = crossProduct < 0 ? RoundaboutDirection.COUNTERCLOCKWISE :
+                        (crossProduct > 0) ? RoundaboutDirection.CLOCKWISE : RoundaboutDirection.UNKNOWN;
+    
+                // If the direction is UNKNOWN then we continue to the next iteration because we do not
+                // Have any new information about the roundabout's direction
+                if(direction.equals(RoundaboutDirection.UNKNOWN)) {
+                    continue;
+                }
+    
+                // If the directionSoFar is UNKNOWN, and the direction derived from the current pair
+                // Of edges is not UNKNOWN, make the directionSoFar equal to the current pair direction
+                if (directionSoFar.equals(RoundaboutDirection.UNKNOWN)) {
+                    directionSoFar = direction;
+                }
+                // Otherwise, if the directionSoFar and the direction are not equal, we know that the
+                // Roundabout has segments going in different directions
+                else if (!directionSoFar.equals(direction)){
+                    return RoundaboutDirection.MULTIDIRECTIONAL;
+                }
+            }
+            return directionSoFar;
+        }
+```java
+
+    public enum roundaboutDirection
+        {
+            CLOCKWISE,
+            COUNTERCLOCKWISE,
+            MULTIDIRECTIONAL,
+            UNKNOWN
+        }
+```
+
+Using the roundabout's direction and the iso_country_code tag on a given feature, we can determine
+whether the roundabout is moving in the incorrect direction. If the roundabout is in a right-driving
+country and the traffic is moving in the clockwise direction or if the roundabout is in a left-driving
+country and the traffic is moving in the counterclockwise direction then a flag is thrown.
+If the findRoundaboutDirection method found that the roundabout was multi-directional, then we flag that
+as well.
+
+```java
+ @Override
+     protected Optional<CheckFlag> flag(final AtlasObject object)
+     {
+         final Edge edge = (Edge) object;
+         final String isoCountryCode = edge.tag(ISOCountryTag.KEY).toUpperCase();
+ 
+         // Get all edges in the roundabout
+         final List<Edge> roundaboutEdges = getAllRoundaboutEdges(edge);
+ 
+         // Get the direction of the roundabout
+         final RoundaboutDirection direction = findRoundaboutDirection(roundaboutEdges);
+ 
+         // Determine if the roundabout is in a left or right driving country
+         final boolean isLeftDriving = LEFT_DRIVING_COUNTRIES.contains(isoCountryCode);
+ 
+         // If the roundabout is found to be going in multiple directions
+         if (direction.equals(RoundaboutDirection.MULTIDIRECTIONAL)) {
+             return Optional.of(this.createFlag(new HashSet<>(roundaboutEdges),
+                     this.getLocalizedInstruction(1, edge.getOsmIdentifier())));
+         }
+         // If the roundabout traffic is clockwise in a right-driving country, or
+         // If the roundabout traffic is counterclockwise in a left-driving country
+         if (direction.equals(RoundaboutDirection.CLOCKWISE) && !isLeftDriving
+                 || direction.equals(RoundaboutDirection.COUNTERCLOCKWISE) && isLeftDriving)
+         {
+             return Optional.of(this.createFlag(new HashSet<>(roundaboutEdges),
+                     this.getLocalizedInstruction(0, edge.getOsmIdentifier())));
+         }
+ 
+         return Optional.empty();
+     }
+
+```
+
+To learn more about the code, please look at the comments in the source code for the check.
+[MalformedRoundaboutCheck.java](../../src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java)

--- a/docs/checks/waterbodyAndIslandSizeCheck.md
+++ b/docs/checks/waterbodyAndIslandSizeCheck.md
@@ -1,0 +1,89 @@
+# Waterbody and Island Size Check
+
+#### Description
+This check identifies waterbodies that are either to small, or too large in size. Each waterbody and islands' surface area is calculated and compared to minimum and maximum values set in the configuration. Meters squared is the unit of measurement for minimum values, while kilometers squared used when calculating and comparing maximum values.
+
+#### Live Example
+1) This [MultiPolygon Water Relation](https://www.openstreetmap.org/relation/2622285#map=14/59.2859/14.6538) is tagged `natural=WATER`. In this case, the inner members are islands, while the outer member is the waterbody. This particular inner members' ([osm id:372647498](https://www.openstreetmap.org/way/372647498)) surface area is less 10 squared meters.
+ 
+2) This islet ([osm id: 23240011](https://www.openstreetmap.org/way/23240011)) is larger than the configured maximum surface area. According to OSM, any islet greater than 1 kilometer squared should be tagged as `place=ISLAND`.
+
+#### Code Review
+In [Atlas](https://github.com/osmlab/atlas), OSM elements are represented as Edges, Points, Lines, 
+Nodes & Relations; in our case, we’re are looking at [Areas](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Area.java) and [Relations](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java).
+
+Our first goal is to validate the incoming Atlas object. Valid features for this check will satisfy
+the following conditions:
+* Must be an Area with one of the following tags:
+    * `natural=WATER`
+    * `place=ISLET`
+    * `place=ISLAND`
+    * `place=ARCHIPELAGO`
+* If Object is a Relation, the following must be ture:
+    * Has `type=MULTIPOLYGON` & `natural=WATER` tags
+    * Has at least 2 members 
+
+```java
+    @Override
+        public boolean validCheckForObject(final AtlasObject object)
+        {
+        // Object must be either a MultiPolygon Relation with at least one member, or an Area with
+        // a place=islet, place=island, place=archipelago, or natural=water tag
+        return (object instanceof Relation && IS_MULTIPOLYGON_WATER_RELATION.test(object)
+                && ((Relation) object).members().size() >= 2)
+                || (object instanceof Area
+                        && (TagPredicates.IS_WATER_BODY.test(object) || IS_ISLET.test(object)
+                                || IS_ISLAND.test(object))
+                        && !this.isFlagged(object.getIdentifier()));
+```
+
+After our preliminary filtering, we categorize each object as either an Area or Relation, and go from there. If the object is an Area, we simply calculate the surface area in meters and kilometers, and check whether the island, waterbody, or islet is larger or smaller than the configured maximums and minimums. 
+
+```java
+        if (object instanceof Area)
+        {
+            final Area area = (Area) object;
+            final Surface surfaceArea = area.asPolygon().surface();
+            final double surfaceAreaMeters = surfaceArea.asMeterSquared();
+            final double surfaceAreaKilometers = surfaceArea.asKilometerSquared();
+...
+        }
+```
+
+If the object is a Relation, we must calculate the surface area of each individual member. Similar to above, upon completion of surface area calculation, we can compare the members value to the configured maximum and minimum waterbody and island sizes.
+
+```java
+    private Optional<CheckFlag> getMultiPolygonRelationFlags(final Relation relation,
+            final Set<RelationMember> relationMembers)
+    {
+        final CheckFlag flag = new CheckFlag(this.getTaskIdentifier(relation));
+
+        for (final RelationMember member : relationMembers)
+        {
+            final Surface surfaceArea = ((Area) member.getEntity()).asPolygon().surface();
+            final double surfaceAreaMeters = surfaceArea.asMeterSquared();
+            final double surfaceAreaKilometers = surfaceArea.asKilometerSquared();
+            final long memberOsmId = member.getEntity().getOsmIdentifier();
+            
+            // Multipolygon Island Relations
+            if (member.getRole().equals(RelationTypeTag.MULTIPOLYGON_ROLE_INNER))
+            {
+                if (surfaceAreaMeters < this.islandMinimumArea 
+                        || surfaceAreaKilometers > this.islandMaximumArea)
+...
+            }
+
+            // Multipolygon water body Relations
+            if (member.getRole().equals(RelationTypeTag.MULTIPOLYGON_ROLE_OUTER))
+            {
+                if (surfaceAreaMeters < this.waterbodyMinimumArea
+                        || surfaceAreaKilometers > this.waterbodyMaximumArea)
+...
+            }
+        }
+
+    }
+```
+
+To learn more about the code, please look at the comments in the source code for the check.
+[WaterbodyAndIslandSizeCheck.java](../../src/main/java/org/openstreetmap/atlas/checks/validation/areas/WaterbodyAndIslandSizeCheck.java)

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -20,13 +20,13 @@ There are a couple of requirements for building and running a new Atlas Check. T
 
 ### Building Check Template
 Building a check template is as easy as running a very basic command using gradle:
-`gradle buildCheck -PCheckName=CheckName`
+`./gradlew buildCheck -PCheckName=CheckName`
 
 The value "CheckName" can and should be changed with whatever represents the check that you are planning to 
 write more clearly. So if you are writing a check to make sure that any areas tagged as pools are not larger 
 than a certain maximum or smaller than a certain minimum, then we might call that check "PoolSizeCheck", 
 and would be done like so:
-`gradle buildCheck -PCheckName=PoolSizeCheck`
+`./gradlew buildCheck -PCheckName=PoolSizeCheck`
 
 This command would be required to be run inside the Atlas-Checks root folder, and would provide the following updates:
 - Creates new file src/main/java/org/openstreetmap/atlas/checks/validation/PoolSizeCheck
@@ -142,7 +142,7 @@ all the configuration values for the system and the checks themselves. For more 
 #### Results
 
 To execute our check(s), we simply need to run the following gradle command:
-`gradle run`
+`./gradlew run`
 
 This will execute our flag using the default configuration. For executing with advanced properties see 
 [Atlas Checks Standalone Application](standalone.md).

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -18,7 +18,7 @@ Gradle will look inside this folder [data/](../data/) for any atlas or PBF files
 Atlas Checks allows you to run the checks against PBF files. If you have downloaded a PBF file you can simply
 place the PBF in the [data/](../data/) directory and execute
 
-`gradle run`
+`./gradlew run`
 
 If you want to supply a location to a remote PBF you can use a project property in Gradle to set the PBF location
 and execute
@@ -33,7 +33,7 @@ area allows Atlas Checks to complete faster, or simply for focus. Like running a
 the PBF file using either a URL location or a local file, but in this case you would include the bounding
 box as well.
 
-`gradle run -Pchecks.local.input=https://download.geofabrik.de/africa/south-africa-latest.osm.pbf -Pchecks.local.pbfBoundingBox=lat,lon:lat,lon`
+`./gradlew run -Pchecks.local.input=https://download.geofabrik.de/africa/south-africa-latest.osm.pbf -Pchecks.local.pbfBoundingBox=lat,lon:lat,lon`
 
 In the above case you would replace lat,lon:lat,lon with the actual bounds of your box.
 
@@ -44,7 +44,7 @@ execute the checks over the Atlas file. Ordinarily the Atlas file will simply be
 then garbage collected once we are finished with it. However it may be useful to save the Atlas for later usage, you
 can do this by adding the `savePbfAtlas` flag to your gradle command, like so:
 
-`gradle run -Pchecks.local.savePbfAtlas=true`
+`./gradlew run -Pchecks.local.savePbfAtlas=true`
 
 #### Output File Formats
 
@@ -60,7 +60,7 @@ GeometryCollection within a GeoJson Feature that has aggregate information withi
 By default, all output formats are enabled. This can be changed by setting the `outputFormat` flag to a comma-separated list'
 of desired formats, like so:
 
-`gradle run -Pchecks.local.outputFormats=geojson,metrics`
+`./gradlew run -Pchecks.local.outputFormats=geojson,metrics`
 
 #### Publish directly to MapRoulette
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Aug 07 14:37:03 PDT 2017
+#Thu May 10 08:52:16 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
@@ -167,7 +167,7 @@ public class Challenge implements Serializable
             challengeJson.add(KEY_NAME, new JsonPrimitive(challengeName));
         }
 
-        if (this.defaultPriority != null && this.defaultPriority != ChallengePriority.NONE)
+        if (this.defaultPriority != null)
         {
             challengeJson.add(KEY_DEFAULT_PRIORITY,
                     new JsonPrimitive(this.defaultPriority.intValue()));

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/WaterbodyAndIslandSizeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/WaterbodyAndIslandSizeCheck.java
@@ -1,0 +1,275 @@
+package org.openstreetmap.atlas.checks.validation.areas;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.checks.atlas.predicates.TagPredicates;
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.Area;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
+import org.openstreetmap.atlas.tags.NaturalTag;
+import org.openstreetmap.atlas.tags.PlaceTag;
+import org.openstreetmap.atlas.tags.RelationTypeTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.scalars.Surface;
+
+/**
+ * This check identifies waterbodies and islands that are either too small, or too large in size.
+ * Minimum surface area values are measured in meters squared; while maximum values are measured in
+ * kilometers squared. We use two units of conversion to avoid very small/large values. For example,
+ * 10 meters squared is .00001 kilometers, and 2,000,000 kilometers squared is 2,000,000,000 meters
+ * squared. An island can either be tagged as place=island, place=islet, place=archipelago, or a
+ * MultiPolygon Relation with the type=multipolygon and natural=water tags.
+ *
+ * @author danielbaah
+ */
+public class WaterbodyAndIslandSizeCheck extends BaseCheck
+{
+
+    private static final long serialVersionUID = 4105386144665109331L;
+    private static String WATERBODY_INSTRUCTION = "Waterbody with OSM ID {0,number,#} has a surface"
+            + " area of {1,number,#.##} meters squared, which is outside of the expected surface area"
+            + " range of {2} square meters to {3} square kilometers.";
+    private static String ISLAND_INSTRUCTION = "Island with OSM ID {0,number,#} has a surface area"
+            + " of {1,number,#.##} meters squared, which is outside of the expected surface area "
+            + "range of {2} square meters to {3} square kilometers.";
+    private static String ISLET_INSTRUCTION = "Islet with OSM ID {0,number,#} has an surface area "
+            + "of {1,number,#.##} meters squared, which is outside of the expected surface area range"
+            + " of {2} square meters to {3} square kilometers. Islets greater than {3} square "
+            + "kilometers should likely be tagged as place=ISLAND.";
+    private static final double WATERBODY_MIN_AREA_DEFAULT = 10;
+    // Waterbody maximum is based on the Caspian Sea surface area, the largest island waterbody in
+    // OSM that is tagged with natural=water.
+    private static final double WATERBODY_MAX_AREA_DEFAULT = 337000;
+    private static final double ISLAND_MIN_AREA_DEFAULT = 10;
+    // Island maximum is based on Greenland surface area, the largest island in OSM tagged as
+    // place=island. The next largest landmass is Australia which is a continent and not an island.
+    private static final double ISLAND_MAX_AREA_DEFAULT = 2170000;
+    private static final double ISLET_MIN_AREA_DEFAULT = 10;
+    // Islet maximum is specified by OSM Wiki (https://wiki.openstreetmap.org/wiki/Tag:place=islet)
+    private static final double ISLET_MAX_AREA_DEFAULT = 1;
+    private static final Predicate<AtlasObject> IS_ISLET = object -> Validators.isOfType(object,
+            PlaceTag.class, PlaceTag.ISLET);
+    private static final Predicate<AtlasObject> IS_ISLAND = object -> Validators.isOfType(object,
+            PlaceTag.class, PlaceTag.ISLAND, PlaceTag.ARCHIPELAGO);
+    // Multipolygon Relation must have type=multipolygon and natural=water tags
+    private static final Predicate<AtlasObject> IS_MULTIPOLYGON_WATER_RELATION = object -> Validators
+            .isOfType(object, RelationTypeTag.class, RelationTypeTag.MULTIPOLYGON)
+            && (Validators.isOfType(object, NaturalTag.class, NaturalTag.WATER));
+    private final double waterbodyMinimumArea;
+    private final double waterbodyMaximumArea;
+    private final double islandMinimumArea;
+    private final double islandMaximumArea;
+    private final double isletMinimumArea;
+    private final double isletMaximumArea;
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(WATERBODY_INSTRUCTION,
+            ISLAND_INSTRUCTION, ISLET_INSTRUCTION);
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
+    /**
+     * The default constructor that must be supplied. The Atlas Checks framework will generate the
+     * checks with this constructor, supplying a configuration that can be used to adjust any
+     * parameters that the check uses during operation.
+     *
+     * @param configuration
+     *            the JSON configuration for this check
+     */
+    public WaterbodyAndIslandSizeCheck(final Configuration configuration)
+    {
+        super(configuration);
+        this.waterbodyMinimumArea = (double) configurationValue(configuration,
+                "surface.waterbody.minimum.meters", WATERBODY_MIN_AREA_DEFAULT);
+        this.waterbodyMaximumArea = (double) configurationValue(configuration,
+                "surface.waterbody.maximum.kilometers", WATERBODY_MAX_AREA_DEFAULT);
+        this.islandMinimumArea = (double) configurationValue(configuration,
+                "surface.island.minimum.meters", ISLAND_MIN_AREA_DEFAULT);
+        this.islandMaximumArea = (double) configurationValue(configuration,
+                "surface.island.maximum.kilometers", ISLAND_MAX_AREA_DEFAULT);
+        this.isletMinimumArea = (double) configurationValue(configuration,
+                "surface.islet.minimum.meters", ISLET_MIN_AREA_DEFAULT);
+        this.isletMaximumArea = (double) configurationValue(configuration,
+                "surface.islet.maximum.kilometers", ISLET_MAX_AREA_DEFAULT);
+    }
+
+    /**
+     * This function will validate if the supplied atlas object is valid for the check.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return {@code true} if this object should be checked
+     */
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        // Object must be either a MultiPolygon Relation with at least one member, or an Area with
+        // a place=islet, place=island, place=archipelago, or natural=water tag
+        return (object instanceof Relation && IS_MULTIPOLYGON_WATER_RELATION.test(object)
+                && ((Relation) object).members().size() >= 2)
+                || (object instanceof Area
+                        && (TagPredicates.IS_WATER_BODY.test(object) || IS_ISLET.test(object)
+                                || IS_ISLAND.test(object))
+                        && !this.isFlagged(object.getIdentifier()));
+    }
+
+    /**
+     * This is the actual function that will check to see whether the object needs to be flagged.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return an optional {@link CheckFlag} object that
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        if (object instanceof Area)
+        {
+            final Area area = (Area) object;
+            final Surface surfaceArea = area.asPolygon().surface();
+            final double surfaceAreaMeters = surfaceArea.asMeterSquared();
+            final double surfaceAreaKilometers = surfaceArea.asKilometerSquared();
+            // Mark each object because we could potentially run into Multipolygon entities that get
+            // passed in as Areas
+            this.markAsFlagged(area.getIdentifier());
+
+            // natural=water tag
+            if (TagPredicates.IS_WATER_BODY.test(object))
+            {
+                if (surfaceAreaMeters < this.waterbodyMinimumArea
+                        || surfaceAreaKilometers > this.waterbodyMaximumArea)
+                {
+                    return Optional.of(this.createFlag(object,
+                            this.getLocalizedInstruction(0, object.getOsmIdentifier(),
+                                    surfaceAreaMeters, this.waterbodyMinimumArea,
+                                    this.waterbodyMaximumArea)));
+                }
+            }
+            // place=island or place=archipelago tags
+            if (IS_ISLAND.test(object))
+            {
+                if (surfaceAreaMeters < this.islandMinimumArea
+                        || surfaceAreaKilometers > this.islandMaximumArea)
+                {
+                    return Optional.of(this.createFlag(object,
+                            this.getLocalizedInstruction(1, object.getOsmIdentifier(),
+                                    surfaceAreaMeters, this.islandMinimumArea,
+                                    this.islandMaximumArea)));
+                }
+            }
+            // place=islet tag
+            if (IS_ISLET.test(object))
+            {
+                if (surfaceAreaMeters < this.isletMinimumArea
+                        || surfaceAreaKilometers > this.isletMaximumArea)
+                {
+                    return Optional.of(this.createFlag(object,
+                            this.getLocalizedInstruction(2, object.getOsmIdentifier(),
+                                    surfaceAreaMeters, this.isletMinimumArea,
+                                    this.isletMaximumArea)));
+                }
+            }
+        }
+        // There are two Relations to examine:
+        // 1. Islands included as members of a MultiPolygon (not otherwise tagged as place=island or
+        // place=islet)
+        // 2. Water bodies included as members of a Multipolygon (not otherwise tagged as
+        // natural=water)
+        // Each Relation will have n numbers of instructions, dependent on the amount of members
+        // that fail the size check
+        else if (object instanceof Relation)
+        {
+            final Relation relation = (Relation) object;
+            // Get Relation members that are an Area, have either an inner or outer member,
+            // and have yet to be examined
+            final Set<RelationMember> relationMembers = relation.members().stream()
+                    .filter(this::isValidMultiPolygonRelationMember).collect(Collectors.toSet());
+
+            if (!relationMembers.isEmpty())
+            {
+                return this.getMultiPolygonRelationFlags(relation, relationMembers);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Helper function for filtering invalid Relation members. Each Relation member must be an Area,
+     * have either an inner or outer role, and the inner role must not contain the natural=rock tag.
+     *
+     * @param member
+     *            - RelationMember
+     * @return true if member is valid
+     */
+    private boolean isValidMultiPolygonRelationMember(final RelationMember member)
+    {
+        return member.getEntity() instanceof Area
+                && !this.isFlagged(member.getEntity().getIdentifier())
+                && (member.getRole().equals(RelationTypeTag.MULTIPOLYGON_ROLE_OUTER)
+                        || (member.getRole().equals(RelationTypeTag.MULTIPOLYGON_ROLE_INNER)
+                                && !Validators.isOfType(member.getEntity(), NaturalTag.class,
+                                        NaturalTag.ROCK)));
+    }
+
+    /**
+     * This function calculates the surface area of an individual Relation Member & creates an
+     * CheckFlag Optional with instruction and member entities it fails the surface area test.
+     *
+     * @param relation
+     *            - Relation
+     * @param relationMembers
+     *            - Valid Relation members
+     * @return CheckFlag Optional
+     */
+    private Optional<CheckFlag> getMultiPolygonRelationFlags(final Relation relation,
+            final Set<RelationMember> relationMembers)
+    {
+        final CheckFlag flag = new CheckFlag(this.getTaskIdentifier(relation));
+
+        for (final RelationMember member : relationMembers)
+        {
+            final Surface surfaceArea = ((Area) member.getEntity()).asPolygon().surface();
+            final double surfaceAreaMeters = surfaceArea.asMeterSquared();
+            final double surfaceAreaKilometers = surfaceArea.asKilometerSquared();
+            final long memberOsmId = member.getEntity().getOsmIdentifier();
+
+            // Multipolygon Island Relations
+            if (member.getRole().equals(RelationTypeTag.MULTIPOLYGON_ROLE_INNER))
+            {
+                if (surfaceAreaMeters < this.islandMinimumArea
+                        || surfaceAreaKilometers > this.islandMaximumArea)
+                {
+                    flag.addInstruction(this.getLocalizedInstruction(1, memberOsmId,
+                            surfaceAreaMeters, this.islandMinimumArea, this.islandMaximumArea));
+                    flag.addObject(member.getEntity());
+                }
+            }
+            // Multipolygon water body Relations
+            if (member.getRole().equals(RelationTypeTag.MULTIPOLYGON_ROLE_OUTER))
+            {
+                if (surfaceAreaMeters < this.waterbodyMinimumArea
+                        || surfaceAreaKilometers > this.waterbodyMaximumArea)
+                {
+                    flag.addInstruction(
+                            this.getLocalizedInstruction(0, memberOsmId, surfaceAreaMeters,
+                                    this.waterbodyMinimumArea, this.waterbodyMaximumArea));
+                    flag.addObject(member.getEntity());
+                }
+            }
+        }
+
+        return !flag.getFlaggedObjects().isEmpty() ? Optional.of(flag) : Optional.empty();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheck.java
@@ -50,7 +50,7 @@ public class IntersectingBuildingsCheck extends BaseCheck<String>
 
     // Default values for configurable settings
     private static final double INTERSECTION_LOWER_LIMIT_DEFAULT = 0.01;
-    private static final double OVERLAP_LOWER_LIMIT_DEFAULT = 0.90;
+    private static final double OVERLAP_LOWER_LIMIT_DEFAULT = 1.0;
 
     // Minimum number of points for a polygon
     private static final int MINIMUM_POINT_COUNT_FOR_POLYGON = 3;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheck.java
@@ -61,10 +61,7 @@ public class IntersectingBuildingsCheck extends BaseCheck<String>
     // Minimum intersection to be contained
     private static final double overlapLowerLimit = 1.0;
 
-    /*
-     * If the proportion of intersection compared to area of building is more than 2%, then we have
-     * a building intersection
-     */
+    // Overlap below this limit is not considered to be intersecting
     private final double intersectionLowerLimit;
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
@@ -1,0 +1,258 @@
+package org.openstreetmap.atlas.checks.validation.linear.edges;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.tags.ISOCountryTag;
+import org.openstreetmap.atlas.tags.JunctionTag;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * This check flags roundabouts where the directionality is opposite to what it should be, where the
+ * roundabout is multi-directional, or where the roundabout has incorrect geometry (concave).
+ *
+ * @author savannahostrowski
+ */
+
+public class MalformedRoundaboutCheck extends BaseCheck
+{
+    private static final long serialVersionUID = -3018101860747289836L;
+    private static final String WRONG_WAY_INSTRUCTIONS = "This roundabout, {0,number,#}, is going the"
+            + " wrong direction, or has been improperly tagged as a roundabout.";
+    private static final String MULTIDIRECTIONAL_INSTRUCTIONS = "This roundabout, {0,number,#}, is"
+            + " multi-directional, or the roundabout has improper angle geometry.";
+    private static final String[] LEFT_DRIVING_COUNTRIES_DEFAULT = { "AIA", "ATG", "AUS", "BGD",
+            "BHS", "BMU", "BRB", "BRN", "BTN", "BWA", "CCK", "COK", "CXR", "CYM", "CYP", "DMA",
+            "FJI", "FLK", "GBR", "GGY", "GRD", "GUY", "HKG", "IDN", "IMN", "IND", "IRL", "JAM",
+            "JEY", "JPN", "KEN", "KIR", "KNA", "LCA", "LKA", "LSO", "MAC", "MDV", "MLT", "MOZ",
+            "MSR", "MUS", "MWI", "MYS", "NAM", "NFK", "NIU", "NPL", "NRU", "NZL", "PAK", "PCN",
+            "PNG", "SGP", "SGS", "SHN", "SLB", "SUR", "SWZ", "SYC", "TCA", "THA", "TKL", "TLS",
+            "TON", "TTO", "TUV", "TZA", "UGA", "VCT", "VGB", "VIR", "WSM", "ZAF", "ZMB", "ZWE" };
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(WRONG_WAY_INSTRUCTIONS,
+            MULTIDIRECTIONAL_INSTRUCTIONS);
+
+    private Set<String> leftDrivingCountries;
+
+    /**
+     * An enum of RoundaboutDirections
+     */
+    public enum RoundaboutDirection
+    {
+        CLOCKWISE,
+        COUNTERCLOCKWISE,
+        // Handles the case where multiple directions were found in the roundabout
+        MULTIDIRECTIONAL,
+        // Handles the case where we were unable to get any information about the roundabout's
+        // Direction or if the roundabout's geometry was malformed (concave).
+        UNKNOWN
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
+    public MalformedRoundaboutCheck(final Configuration configuration)
+    {
+        super(configuration);
+        this.leftDrivingCountries = new HashSet<>(
+                Arrays.asList((String[]) configurationValue(configuration, "traffic.countries.left",
+                        LEFT_DRIVING_COUNTRIES_DEFAULT)));
+    }
+
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        // We check that the object is an instance of Edge
+        return object instanceof Edge
+                // Make sure that the object has an iso_country_code
+                && object.getTag(ISOCountryTag.KEY).isPresent()
+                // Make sure that the edges are instances of roundabout
+                && JunctionTag.isRoundabout(object)
+                // And that the Edge has not already been marked as flagged
+                && !this.isFlagged(object.getIdentifier())
+                // Make sure that we are only looking at master edges
+                && ((Edge) object).isMasterEdge();
+    }
+
+    /**
+     * This is the actual function that will check to see whether the object needs to be flagged.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return an optional {@link CheckFlag} object that
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final Edge edge = (Edge) object;
+        final String isoCountryCode = edge.tag(ISOCountryTag.KEY).toUpperCase();
+
+        // Get all edges in the roundabout
+        final List<Edge> roundaboutEdges = getAllRoundaboutEdges(edge);
+
+        // Get the direction of the roundabout
+        final RoundaboutDirection direction = findRoundaboutDirection(roundaboutEdges);
+
+        // If the roundabout is found to be going in multiple directions
+        if (direction.equals(RoundaboutDirection.MULTIDIRECTIONAL))
+        {
+            return Optional.of(this.createFlag(new HashSet<>(roundaboutEdges),
+                    this.getLocalizedInstruction(1, edge.getOsmIdentifier())));
+        }
+
+        // Determine if the roundabout is in a left or right driving country
+        final boolean isLeftDriving = leftDrivingCountries.contains(isoCountryCode);
+
+        // If the roundabout traffic is clockwise in a right-driving country, or
+        // If the roundabout traffic is counterclockwise in a left-driving country
+        if (direction.equals(RoundaboutDirection.CLOCKWISE) && !isLeftDriving
+                || direction.equals(RoundaboutDirection.COUNTERCLOCKWISE) && isLeftDriving)
+        {
+            return Optional.of(this.createFlag(new HashSet<>(roundaboutEdges),
+                    this.getLocalizedInstruction(0, edge.getOsmIdentifier())));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * This method gets all edges in a roundabout given one edge in that roundabout, in ascending
+     * Edge identifier order.
+     *
+     * @param edge
+     *            An Edge object known to be a roundabout edge
+     * @return A list of edges in the roundabout
+     */
+    private List<Edge> getAllRoundaboutEdges(final Edge edge)
+    {
+        final List<Edge> roundaboutEdges = new ArrayList<>();
+
+        // Initialize a queue to add yet to be processed connected edges to
+        final Queue<Edge> queue = new LinkedList<>();
+
+        // Mark the current Edge as visited and enqueue it
+        this.markAsFlagged(edge.getIdentifier());
+        queue.add(edge);
+
+        // As long as the queue is not empty
+        while (!queue.isEmpty())
+        {
+            // Dequeue a connected edge and add it to the roundaboutEdges
+            final Edge currentEdge = queue.poll();
+
+            roundaboutEdges.add(currentEdge);
+
+            // Get the edges connected to the edge as an iterator
+            final Set<Edge> connectedEdges = currentEdge.connectedEdges();
+
+            for (final Edge connectedEdge : connectedEdges)
+            {
+                if (JunctionTag.isRoundabout(connectedEdge)
+                        && !roundaboutEdges.contains(connectedEdge))
+                {
+                    this.markAsFlagged(connectedEdge.getIdentifier());
+                    queue.add(connectedEdge);
+                }
+            }
+        }
+        roundaboutEdges.sort(Edge::compareTo);
+        return roundaboutEdges;
+    }
+
+    /**
+     * This method returns a RoundaboutDirection enum which indicates direction of the flow of
+     * traffic based on the cross product of two adjacent edges. This method leverages the
+     * right-hand rule as it relates to the directionality of two vectors.
+     *
+     * @see "https://en.wikipedia.org/wiki/Right-hand_rule"
+     * @param roundaboutEdges
+     *            A list of Edges in a roundabout
+     * @return CLOCKWISE or COUNTERCLOCKWISE if all the edges have positive or negative cross
+     *         products respectively, MULTIDIRECTIONAL if multiple directions are found in the same
+     *         roundabout, and UNKNOWN if all edge cross products are 0 or if the roundabout's
+     *         geometry is malformed
+     */
+    private static RoundaboutDirection findRoundaboutDirection(final List<Edge> roundaboutEdges)
+    {
+        // Initialize the directionSoFar to UNKNOWN as we have no directional information yet
+        RoundaboutDirection directionSoFar = RoundaboutDirection.UNKNOWN;
+
+        for (int idx = 0; idx < roundaboutEdges.size(); idx++)
+        {
+            // Get the Edges to use in the cross product
+            final Edge edge1 = roundaboutEdges.get(idx);
+            // We mod the roundabout edges here so that we can get the last pair of edges in the
+            // Roundabout correctly
+            final Edge edge2 = roundaboutEdges.get((idx + 1) % roundaboutEdges.size());
+            // Get the cross product and then the direction of the roundabout
+            final double crossProduct = getCrossProduct(edge1, edge2);
+            final RoundaboutDirection direction = crossProduct < 0
+                    ? RoundaboutDirection.COUNTERCLOCKWISE
+                    : (crossProduct > 0) ? RoundaboutDirection.CLOCKWISE
+                            : RoundaboutDirection.UNKNOWN;
+
+            // If the direction is UNKNOWN then we continue to the next iteration because we do not
+            // Have any new information about the roundabout's direction
+            if (direction.equals(RoundaboutDirection.UNKNOWN))
+            {
+                continue;
+            }
+
+            // If the directionSoFar is UNKNOWN, and the direction derived from the current pair
+            // Of edges is not UNKNOWN, make the directionSoFar equal to the current pair direction
+            if (directionSoFar.equals(RoundaboutDirection.UNKNOWN))
+            {
+                directionSoFar = direction;
+            }
+            // Otherwise, if the directionSoFar and the direction are not equal, we know that the
+            // Roundabout has segments going in different directions
+            else if (!directionSoFar.equals(direction))
+            {
+                return RoundaboutDirection.MULTIDIRECTIONAL;
+            }
+        }
+        return directionSoFar;
+    }
+
+    /**
+     * This method returns the cross product between two adjacent edges.
+     *
+     * @see "https://en.wikipedia.org/wiki/Cross_product"
+     * @param edge1
+     *            An Edge entity in the roundabout
+     * @param edge2
+     *            An Edge entity in the roundabout adjacent to edge1
+     * @return A double corresponding to the cross product between two edges
+     */
+    private static Double getCrossProduct(final Edge edge1, final Edge edge2)
+    {
+        // Get the nodes' latitudes and longitudes to use in deriving the vectors
+        final double node1Y = edge1.start().getLocation().getLatitude().asDegrees();
+        final double node1X = edge1.start().getLocation().getLongitude().asDegrees();
+        final double node2Y = edge1.end().getLocation().getLatitude().asDegrees();
+        final double node2X = edge1.end().getLocation().getLongitude().asDegrees();
+        final double node3Y = edge2.end().getLocation().getLatitude().asDegrees();
+        final double node3X = edge2.end().getLocation().getLongitude().asDegrees();
+
+        // Get the vectors from node 2 to 1, and node 2 to 3
+        final double vector1X = node2X - node1X;
+        final double vector1Y = node2Y - node1Y;
+        final double vector2X = node2X - node3X;
+        final double vector2Y = node2Y - node3Y;
+
+        // The cross product tells us the direction of the orthogonal vector, which is
+        // Directly related to the direction of rotation/traffic
+        return (vector1X * vector2Y) - (vector1Y * vector2X);
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
@@ -31,17 +31,18 @@ public class MalformedRoundaboutCheck extends BaseCheck
             + " wrong direction, or has been improperly tagged as a roundabout.";
     private static final String MULTIDIRECTIONAL_INSTRUCTIONS = "This roundabout, {0,number,#}, is"
             + " multi-directional, or the roundabout has improper angle geometry.";
-    private static final String[] LEFT_DRIVING_COUNTRIES_DEFAULT = { "AIA", "ATG", "AUS", "BGD",
-            "BHS", "BMU", "BRB", "BRN", "BTN", "BWA", "CCK", "COK", "CXR", "CYM", "CYP", "DMA",
-            "FJI", "FLK", "GBR", "GGY", "GRD", "GUY", "HKG", "IDN", "IMN", "IND", "IRL", "JAM",
-            "JEY", "JPN", "KEN", "KIR", "KNA", "LCA", "LKA", "LSO", "MAC", "MDV", "MLT", "MOZ",
-            "MSR", "MUS", "MWI", "MYS", "NAM", "NFK", "NIU", "NPL", "NRU", "NZL", "PAK", "PCN",
-            "PNG", "SGP", "SGS", "SHN", "SLB", "SUR", "SWZ", "SYC", "TCA", "THA", "TKL", "TLS",
-            "TON", "TTO", "TUV", "TZA", "UGA", "VCT", "VGB", "VIR", "WSM", "ZAF", "ZMB", "ZWE" };
+    private static final List<String> LEFT_DRIVING_COUNTRIES_DEFAULT = Arrays.asList("AIA", "ATG",
+            "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN", "BWA", "CCK", "COK", "CXR", "CYM",
+            "CYP", "DMA", "FJI", "FLK", "GBR", "GGY", "GRD", "GUY", "HKG", "IDN", "IMN", "IND",
+            "IRL", "JAM", "JEY", "JPN", "KEN", "KIR", "KNA", "LCA", "LKA", "LSO", "MAC", "MDV",
+            "MLT", "MOZ", "MSR", "MUS", "MWI", "MYS", "NAM", "NFK", "NIU", "NPL", "NRU", "NZL",
+            "PAK", "PCN", "PNG", "SGP", "SGS", "SHN", "SLB", "SUR", "SWZ", "SYC", "TCA", "THA",
+            "TKL", "TLS", "TON", "TTO", "TUV", "TZA", "UGA", "VCT", "VGB", "VIR", "WSM", "ZAF",
+            "ZMB", "ZWE");
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(WRONG_WAY_INSTRUCTIONS,
             MULTIDIRECTIONAL_INSTRUCTIONS);
 
-    private Set<String> leftDrivingCountries;
+    private List<String> leftDrivingCountries;
 
     /**
      * An enum of RoundaboutDirections
@@ -66,9 +67,8 @@ public class MalformedRoundaboutCheck extends BaseCheck
     public MalformedRoundaboutCheck(final Configuration configuration)
     {
         super(configuration);
-        this.leftDrivingCountries = new HashSet<>(
-                Arrays.asList((String[]) configurationValue(configuration, "traffic.countries.left",
-                        LEFT_DRIVING_COUNTRIES_DEFAULT)));
+        this.leftDrivingCountries = (List<String>) configurationValue(configuration,
+                "traffic.countries.left", LEFT_DRIVING_COUNTRIES_DEFAULT);
     }
 
     @Override

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/WaterbodyAndIslandSizeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/WaterbodyAndIslandSizeTest.java
@@ -1,0 +1,100 @@
+package org.openstreetmap.atlas.checks.validation.areas;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * WaterbodyAndIslandSizeTest unit tests
+ *
+ * @author danielbaah
+ */
+public class WaterbodyAndIslandSizeTest
+{
+    @Rule
+    public WaterbodyAndIslandSizeTestRule setup = new WaterbodyAndIslandSizeTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void largeIsletTest()
+    {
+        this.verifier.actual(this.setup.getLargeIsletAtlas(),
+                new WaterbodyAndIslandSizeCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyNotEmpty();
+    }
+
+    @Test
+    public void validIslandSizeTest()
+    {
+        this.verifier.actual(this.setup.getValidSizeIslandAtlas(),
+                new WaterbodyAndIslandSizeCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void smallArchipelagoTest()
+    {
+        this.verifier.actual(this.setup.getSmallArchipelagoAtlas(),
+                new WaterbodyAndIslandSizeCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyNotEmpty();
+    }
+
+    @Test
+    public void smallWaterbodyTest()
+    {
+        this.verifier.actual(this.setup.getSmallWaterbodyAtlas(),
+                new WaterbodyAndIslandSizeCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyNotEmpty();
+    }
+
+    @Test
+    public void smallIsletAtlas()
+    {
+        this.verifier.actual(this.setup.getSmallIsletAtlas(),
+                new WaterbodyAndIslandSizeCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyNotEmpty();
+    }
+
+    @Test
+    public void smallMultiPolygonIslandTest()
+    {
+        this.verifier.actual(this.setup.getSmallMultiPolygonIslandAtlas(),
+                new WaterbodyAndIslandSizeCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyNotEmpty();
+    }
+
+    @Test
+    public void smallRockMultiPolygonIslandTest()
+    {
+        this.verifier.actual(this.setup.getSmallRockMultiPolygonIslandAtlas(),
+                new WaterbodyAndIslandSizeCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void smallIslandMultiPolygonDuplicateTest()
+    {
+        this.verifier.actual(this.setup.getSmallIslandMultiPolygonDuplicateAtlas(),
+                new WaterbodyAndIslandSizeCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void invalidMultiPolygonNoNaturalWaterTagRelationTest()
+    {
+        this.verifier.actual(this.setup.getInvalidMultiPolygonNoNaturalWaterTagRelationAtlas(),
+                new WaterbodyAndIslandSizeCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void smallMultiPolygonWaterbodyMemberTest()
+    {
+        this.verifier.actual(this.setup.getSmallMultiPolygonWaterbodyMemberAtlas(),
+                new WaterbodyAndIslandSizeCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyNotEmpty();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/WaterbodyAndIslandSizeTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/WaterbodyAndIslandSizeTestRule.java
@@ -1,0 +1,211 @@
+package org.openstreetmap.atlas.checks.validation.areas;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.tags.RelationTypeTag;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
+
+/**
+ * WaterbodyAndIslandSizeTestRule test Atlas
+ *
+ * @author danielbaah
+ */
+public class WaterbodyAndIslandSizeTestRule extends CoreTestRule
+{
+
+    private static final String TEST_1 = "17.65021, -63.24537";
+    private static final String TEST_2 = "17.61776, -63.26013";
+    private static final String TEST_3 = "17.61499, -63.22494";
+    private static final String TEST_4 = "17.64467, -63.21018";
+    private static final String TEST_5 = "17.65024, -63.23069";
+
+    private static final String SMALL_AREA_TEST_1 = "17.64874807036599, -63.22976231575012";
+    private static final String SMALL_AREA_TEST_2 = "17.64874807036599, -63.229751586914055";
+    private static final String SMALL_AREA_TEST_3 = "17.648758294228287, -63.229751586914055";
+    private static final String SMALL_AREA_TEST_4 = "17.648758294228287, -63.22976231575012";
+
+    // Islet with surface area larger than default 10 m^2 maximum
+    @TestAtlas(
+            // Area
+            areas = { @Area(id = "127001", coordinates = { @Loc(value = TEST_1),
+                    @Loc(value = TEST_2), @Loc(value = TEST_3), @Loc(value = TEST_4),
+                    @Loc(value = TEST_5), @Loc(value = TEST_1) }, tags = { "place=islet" }) })
+    private Atlas largeIsletAtlas;
+
+    // Island with valid surface area size
+    @TestAtlas(
+            // Area
+            areas = { @Area(id = "127001", coordinates = { @Loc(value = TEST_1),
+                    @Loc(value = TEST_2), @Loc(value = TEST_3), @Loc(value = TEST_4),
+                    @Loc(value = TEST_5), @Loc(value = TEST_1) }, tags = { "place=island" }) })
+    private Atlas validSizeIslandAtlas;
+
+    // Archipelago island with surface area smaller than default 10 m^2 minimum
+    @TestAtlas(
+            // Area
+            areas = { @Area(id = "127001", coordinates = { @Loc(value = SMALL_AREA_TEST_1),
+                    @Loc(value = SMALL_AREA_TEST_2), @Loc(value = SMALL_AREA_TEST_3),
+                    @Loc(value = SMALL_AREA_TEST_4),
+                    @Loc(value = SMALL_AREA_TEST_1) }, tags = { "place=archipelago" }) })
+    private Atlas smallArchipelagoAtlas;
+
+    // Waterbody with surface area smaller than default 10 m^2
+    @TestAtlas(
+            // Area
+            areas = { @Area(id = "127001", coordinates = { @Loc(value = SMALL_AREA_TEST_1),
+                    @Loc(value = SMALL_AREA_TEST_2), @Loc(value = SMALL_AREA_TEST_3),
+                    @Loc(value = SMALL_AREA_TEST_4),
+                    @Loc(value = SMALL_AREA_TEST_1) }, tags = { "natural=water" }) })
+    private Atlas smallWaterbodyAtlas;
+
+    // Islet with surface area smaller than default 10 m^2
+    @TestAtlas(
+            // Area
+            areas = { @Area(id = "127001", coordinates = { @Loc(value = SMALL_AREA_TEST_1),
+                    @Loc(value = SMALL_AREA_TEST_2), @Loc(value = SMALL_AREA_TEST_3),
+                    @Loc(value = SMALL_AREA_TEST_4),
+                    @Loc(value = SMALL_AREA_TEST_1) }, tags = { "place=islet" }) })
+    private Atlas smallIsletAtlas;
+
+    // MultiPolygon Relation island with surface area smaller than 10 m^2 minimum
+    @TestAtlas(
+            // Areas
+            areas = {
+                    @Area(id = "127001", coordinates = { @Loc(value = SMALL_AREA_TEST_1),
+                            @Loc(value = SMALL_AREA_TEST_2), @Loc(value = SMALL_AREA_TEST_3),
+                            @Loc(value = SMALL_AREA_TEST_4), @Loc(value = SMALL_AREA_TEST_1) }),
+                    @Area(id = "127002", coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_3), @Loc(value = TEST_4), @Loc(value = TEST_5),
+                            @Loc(value = TEST_1) }) },
+            // Relation
+            relations = { @Relation(id = "1001", members = {
+                    @Member(id = "127001", type = "area", role = RelationTypeTag.MULTIPOLYGON_ROLE_INNER),
+                    @Member(id = "127002", type = "area", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER) }, tags = {
+                            "type=multipolygon", "natural=water" }) })
+    private Atlas smallMultiPolygonIslandAtlas;
+
+    // MultiPolygon water Relation missing natural=water tag
+    @TestAtlas(
+            // Areas
+            areas = {
+                    @Area(id = "127001", coordinates = { @Loc(value = SMALL_AREA_TEST_1),
+                            @Loc(value = SMALL_AREA_TEST_2), @Loc(value = SMALL_AREA_TEST_3),
+                            @Loc(value = SMALL_AREA_TEST_4), @Loc(value = SMALL_AREA_TEST_1) }),
+                    @Area(id = "127002", coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_3), @Loc(value = TEST_4), @Loc(value = TEST_5),
+                            @Loc(value = TEST_1) }) },
+            // Relation
+            relations = { @Relation(id = "1001", members = {
+                    @Member(id = "127001", type = "area", role = RelationTypeTag.MULTIPOLYGON_ROLE_INNER),
+                    @Member(id = "127002", type = "area", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER) }, tags = {
+                            "type=multipolygon" }) })
+    private Atlas invalidMultiPolygonNoNaturalWaterTagRelationAtlas;
+
+    // Multipolygon inner member tagged natural=rock. This should be ignored by check
+    @TestAtlas(
+            // Areas
+            areas = {
+                    @Area(id = "127001", coordinates = { @Loc(value = SMALL_AREA_TEST_1),
+                            @Loc(value = SMALL_AREA_TEST_2), @Loc(value = SMALL_AREA_TEST_3),
+                            @Loc(value = SMALL_AREA_TEST_4),
+                            @Loc(value = SMALL_AREA_TEST_1) }, tags = { "natural=rock" }),
+                    @Area(id = "127002", coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_3), @Loc(value = TEST_4), @Loc(value = TEST_5),
+                            @Loc(value = TEST_1) }) },
+            // Relation
+            relations = { @Relation(id = "1001", members = {
+                    @Member(id = "127001", type = "area", role = RelationTypeTag.MULTIPOLYGON_ROLE_INNER),
+                    @Member(id = "127002", type = "area", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER) }, tags = {
+                            "type=multipolygon", "natural=water" }) })
+    private Atlas smallRockMultiPolygonIslandAtlas;
+
+    // Feature 127001 could be flagged as an Area OR a MultiPolygon island
+    @TestAtlas(
+            // Areas
+            areas = {
+                    @Area(id = "127001", coordinates = { @Loc(value = SMALL_AREA_TEST_1),
+                            @Loc(value = SMALL_AREA_TEST_2), @Loc(value = SMALL_AREA_TEST_3),
+                            @Loc(value = SMALL_AREA_TEST_4),
+                            @Loc(value = SMALL_AREA_TEST_1) }, tags = { "place=island" }),
+                    @Area(id = "127002", coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_3), @Loc(value = TEST_4), @Loc(value = TEST_5),
+                            @Loc(value = TEST_1) }) },
+            // Relations
+            relations = { @Relation(id = "1001", members = {
+                    @Member(id = "127001", type = "area", role = RelationTypeTag.MULTIPOLYGON_ROLE_INNER),
+                    @Member(id = "127002", type = "area", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER) }, tags = {
+                            "type=multipolygon", "natural=water" }) })
+    private Atlas smallIslandMultiPolygonDuplicateAtlas;
+
+    // MultiPolygon Relation with outer waterbody member smaller than 10 m^2 miminum
+    @TestAtlas(
+            // Areas
+            areas = {
+                    @Area(id = "127001", coordinates = { @Loc(value = SMALL_AREA_TEST_1),
+                            @Loc(value = SMALL_AREA_TEST_2), @Loc(value = SMALL_AREA_TEST_3),
+                            @Loc(value = SMALL_AREA_TEST_4), @Loc(value = SMALL_AREA_TEST_1) }),
+                    @Area(id = "127002", coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_3), @Loc(value = TEST_4), @Loc(value = TEST_5),
+                            @Loc(value = TEST_1) }) },
+            // Relation
+            relations = { @Relation(id = "1001", members = {
+                    @Member(id = "127002", type = "area", role = RelationTypeTag.MULTIPOLYGON_ROLE_INNER),
+                    @Member(id = "127001", type = "area", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER) }, tags = {
+                            "type=multipolygon", "natural=water" }) })
+    private Atlas smallMultiPolygonWaterbodyMemberAtlas;
+
+    public Atlas getLargeIsletAtlas()
+    {
+        return largeIsletAtlas;
+    }
+
+    public Atlas getValidSizeIslandAtlas()
+    {
+        return validSizeIslandAtlas;
+
+    }
+
+    public Atlas getSmallArchipelagoAtlas()
+    {
+        return smallArchipelagoAtlas;
+    }
+
+    public Atlas getSmallWaterbodyAtlas()
+    {
+        return smallWaterbodyAtlas;
+    }
+
+    public Atlas getSmallIsletAtlas()
+    {
+        return smallIsletAtlas;
+    }
+
+    public Atlas getSmallMultiPolygonIslandAtlas()
+    {
+        return smallMultiPolygonIslandAtlas;
+    }
+
+    public Atlas getSmallRockMultiPolygonIslandAtlas()
+    {
+        return smallRockMultiPolygonIslandAtlas;
+    }
+
+    public Atlas getSmallIslandMultiPolygonDuplicateAtlas()
+    {
+        return smallIslandMultiPolygonDuplicateAtlas;
+    }
+
+    public Atlas getInvalidMultiPolygonNoNaturalWaterTagRelationAtlas()
+    {
+        return invalidMultiPolygonNoNaturalWaterTagRelationAtlas;
+    }
+
+    public Atlas getSmallMultiPolygonWaterbodyMemberAtlas()
+    {
+        return smallMultiPolygonWaterbodyMemberAtlas;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheckTest.java
@@ -103,17 +103,16 @@ public class IntersectingBuildingsCheckTest
     }
 
     @Test
-    public void testSmallIntersectionBuildingsAtlasWithSmallOverlapLowerLimit()
+    public void containsBuildingAtlas()
     {
-        this.verifier.actual(this.setup.smallIntersectionBuildingsAtlas(),
-                new IntersectingBuildingsCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"IntersectingBuildingsCheck\": {\"intersection.lower.limit\": 0.01, \"overlap.lower.limit\": 0.10}}")));
+        this.verifier.actual(this.setup.containsBuildingAtlas(), CHECK);
         this.verifier.verifyNotEmpty();
         this.verifier.verifyExpectedSize(1);
         this.verifier.verify(flag ->
         {
             Assert.assertEquals(2, flag.getFlaggedObjects().size());
-            Assert.assertTrue(flag.getInstructions().contains("overlapped by another building"));
+            Assert.assertTrue(flag.getInstructions()
+                    .contains("Building (id=1234567) contains building (id=2234567)."));
         });
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsTestCaseRule.java
@@ -13,8 +13,8 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
  */
 public class IntersectingBuildingsTestCaseRule extends CoreTestRule
 {
-    private static final String TEST_1 = "47.620079, -122.206879";
-    private static final String TEST_2 = "47.619576, -122.206917";
+    private static final String TEST_1 = "47.620200, -122.206879";
+    private static final String TEST_2 = "47.619500, -122.206917";
     private static final String TEST_3 = "47.620094, -122.205856";
     private static final String TEST_4 = "47.619587, -122.205833";
     private static final String TEST_5 = "47.620087, -122.204948";
@@ -82,6 +82,15 @@ public class IntersectingBuildingsTestCaseRule extends CoreTestRule
                     @Loc(value = TEST_6), @Loc(value = TEST_2) }, tags = { "building=yes" }) })
     private Atlas severalDuplicateBuildingsAtlas;
 
+    @TestAtlas(areas = {
+            // a building
+            @Area(id = "1234567000000", coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                    @Loc(value = TEST_6), @Loc(value = TEST_5) }, tags = { "building=yes" }),
+            // another building with same footprint
+            @Area(id = "2234567000000", coordinates = { @Loc(value = TEST_7), @Loc(value = TEST_8),
+                    @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building=yes" }) })
+    private Atlas containsBuildingAtlas;
+
     public Atlas duplicateBuildingsAtlas()
     {
         return this.duplicateBuildingsAtlas;
@@ -110,5 +119,10 @@ public class IntersectingBuildingsTestCaseRule extends CoreTestRule
     public Atlas smallIntersectionBuildingsAtlas()
     {
         return this.smallIntersectionBuildingsAtlas;
+    }
+
+    public Atlas containsBuildingAtlas()
+    {
+        return this.containsBuildingAtlas;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
@@ -1,0 +1,66 @@
+package org.openstreetmap.atlas.checks.validation.linear.edges;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * Tests for {@link MalformedRoundaboutCheck}
+ *
+ * @author savannahostrowski
+ */
+public class MalformedRoundaboutCheckTest
+{
+    @Rule
+    public MalformedRoundaboutCheckTestRule setup = new MalformedRoundaboutCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void testClockwiseRoundaboutLeftDrivingAtlas()
+    {
+        this.verifier.actual(this.setup.clockwiseRoundaboutLeftDrivingAtlas(),
+                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testClockwiseRoundaboutRightDrivingAtlas()
+    {
+        this.verifier.actual(this.setup.clockwiseRoundaboutRightDrivingAtlas(),
+                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void testCounterClockwiseRoundaboutLeftDrivingAtlas()
+    {
+        this.verifier.actual(this.setup.counterClockwiseRoundaboutLeftDrivingAtlas(),
+                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void testCounterClockwiseRoundaboutRightDrivingAtlas()
+    {
+        this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingAtlas(),
+                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testMultiDirectionalRoundaboutAtlas()
+    {
+        this.verifier.actual(this.setup.multiDirectionalRoundaboutAtlas(),
+                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTestRule.java
@@ -1,0 +1,190 @@
+package org.openstreetmap.atlas.checks.validation.linear.edges;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * {@link MalformedRoundaboutCheckTest} data generator
+ *
+ * @author savannahostrowski
+ */
+
+public class MalformedRoundaboutCheckTestRule extends CoreTestRule
+{
+    private static final String CLOCKWISE_1 = "38.905336130818505,-77.03197002410889";
+    private static final String CLOCKWISE_2 = "38.90558660084624,-77.03158378601074";
+    private static final String CLOCKWISE_3 = "38.905995699991145,-77.0318305492401";
+    private static final String CLOCKWISE_4 = "38.90582872103308,-77.03239917755127";
+    private static final String CLOCKWISE_5 = "38.905494761938684,-77.03236699104309";
+
+    private static final String COUNTER_CLOCKWISE_1 = "38.905361177861046,-77.03205585479736";
+    private static final String COUNTER_CLOCKWISE_2 = "38.905528157918816,-77.03158378601074";
+    private static final String COUNTER_CLOCKWISE_3 = "38.905937257400495,-77.031809091568";
+    private static final String COUNTER_CLOCKWISE_4 = "38.90588716371307,-77.03230261802673";
+    private static final String COUNTER_CLOCKWISE_5 = "38.90551980892527,-77.03236699104309";
+
+    // Clockwise roundabout, left driving country
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = CLOCKWISE_1)),
+                    @Node(coordinates = @Loc(value = CLOCKWISE_2)),
+                    @Node(coordinates = @Loc(value = CLOCKWISE_3)),
+                    @Node(coordinates = @Loc(value = CLOCKWISE_4)),
+                    @Node(coordinates = @Loc(value = CLOCKWISE_5)) },
+            // edges
+            edges = {
+                    @Edge(id = "1234", coordinates = { @Loc(value = CLOCKWISE_1),
+                            @Loc(value = CLOCKWISE_5) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP" }),
+                    @Edge(id = "1235", coordinates = { @Loc(value = CLOCKWISE_5),
+                            @Loc(value = CLOCKWISE_4) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP" }),
+                    @Edge(id = "1236", coordinates = { @Loc(value = CLOCKWISE_4),
+                            @Loc(value = CLOCKWISE_3) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP" }),
+                    @Edge(id = "1237", coordinates = { @Loc(value = CLOCKWISE_3),
+                            @Loc(value = CLOCKWISE_2) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP" }),
+                    @Edge(id = "1238", coordinates = { @Loc(value = CLOCKWISE_2),
+                            @Loc(value = CLOCKWISE_1) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP" }) })
+    private Atlas clockwiseRoundaboutLeftDrivingAtlas;
+
+    // Clockwise roundabout, right driving country
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = CLOCKWISE_1)),
+                    @Node(coordinates = @Loc(value = CLOCKWISE_2)),
+                    @Node(coordinates = @Loc(value = CLOCKWISE_3)),
+                    @Node(coordinates = @Loc(value = CLOCKWISE_4)),
+                    @Node(coordinates = @Loc(value = CLOCKWISE_5)) },
+            // edges
+            edges = {
+                    @Edge(id = "1234", coordinates = { @Loc(value = CLOCKWISE_1),
+                            @Loc(value = CLOCKWISE_5) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA" }),
+                    @Edge(id = "1235", coordinates = { @Loc(value = CLOCKWISE_5),
+                            @Loc(value = CLOCKWISE_4) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA" }),
+                    @Edge(id = "1236", coordinates = { @Loc(value = CLOCKWISE_4),
+                            @Loc(value = CLOCKWISE_3) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA" }),
+                    @Edge(id = "1237", coordinates = { @Loc(value = CLOCKWISE_3),
+                            @Loc(value = CLOCKWISE_2) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA" }),
+                    @Edge(id = "1238", coordinates = { @Loc(value = CLOCKWISE_2),
+                            @Loc(value = CLOCKWISE_1) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA" }) })
+    private Atlas clockwiseRoundaboutRightDrivingAtlas;
+
+    // Counterclockwise roundabout, left driving country
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = COUNTER_CLOCKWISE_1)),
+                    @Node(coordinates = @Loc(value = COUNTER_CLOCKWISE_2)),
+                    @Node(coordinates = @Loc(value = COUNTER_CLOCKWISE_3)),
+                    @Node(coordinates = @Loc(value = COUNTER_CLOCKWISE_4)),
+                    @Node(coordinates = @Loc(value = COUNTER_CLOCKWISE_5)) },
+            // edges
+            edges = {
+                    @Edge(id = "1234", coordinates = { @Loc(value = COUNTER_CLOCKWISE_1),
+                            @Loc(value = COUNTER_CLOCKWISE_2) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP" }),
+                    @Edge(id = "1235", coordinates = { @Loc(value = COUNTER_CLOCKWISE_2),
+                            @Loc(value = COUNTER_CLOCKWISE_3) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP" }),
+                    @Edge(id = "1236", coordinates = { @Loc(value = COUNTER_CLOCKWISE_3),
+                            @Loc(value = COUNTER_CLOCKWISE_4) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP" }),
+                    @Edge(id = "1237", coordinates = { @Loc(value = COUNTER_CLOCKWISE_4),
+                            @Loc(value = COUNTER_CLOCKWISE_5) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP" }),
+                    @Edge(id = "1238", coordinates = { @Loc(value = COUNTER_CLOCKWISE_5),
+                            @Loc(value = COUNTER_CLOCKWISE_1) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP" }) })
+    private Atlas counterClockwiseRoundaboutLeftDrivingAtlas;
+
+    // Counterclockwise roundabout, right driving country
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = COUNTER_CLOCKWISE_1)),
+                    @Node(coordinates = @Loc(value = COUNTER_CLOCKWISE_2)),
+                    @Node(coordinates = @Loc(value = COUNTER_CLOCKWISE_3)),
+                    @Node(coordinates = @Loc(value = COUNTER_CLOCKWISE_4)),
+                    @Node(coordinates = @Loc(value = COUNTER_CLOCKWISE_5)) },
+            // edges
+            edges = {
+                    @Edge(id = "1234", coordinates = { @Loc(value = COUNTER_CLOCKWISE_1),
+                            @Loc(value = COUNTER_CLOCKWISE_2) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA" }),
+                    @Edge(id = "1235", coordinates = { @Loc(value = COUNTER_CLOCKWISE_2),
+                            @Loc(value = COUNTER_CLOCKWISE_3) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA" }),
+                    @Edge(id = "1236", coordinates = { @Loc(value = COUNTER_CLOCKWISE_3),
+                            @Loc(value = COUNTER_CLOCKWISE_4) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA" }),
+                    @Edge(id = "1237", coordinates = { @Loc(value = COUNTER_CLOCKWISE_4),
+                            @Loc(value = COUNTER_CLOCKWISE_5) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA" }),
+                    @Edge(id = "1238", coordinates = { @Loc(value = COUNTER_CLOCKWISE_5),
+                            @Loc(value = COUNTER_CLOCKWISE_1) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA" }) })
+    private Atlas counterClockwiseRoundaboutRightDrivingAtlas;
+
+    // Multi-directional Atlas
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = CLOCKWISE_1)),
+                    @Node(coordinates = @Loc(value = CLOCKWISE_2)),
+                    @Node(coordinates = @Loc(value = COUNTER_CLOCKWISE_1)),
+                    @Node(coordinates = @Loc(value = COUNTER_CLOCKWISE_2)),
+                    @Node(coordinates = @Loc(value = COUNTER_CLOCKWISE_3)) },
+            // edges
+            edges = {
+                    @Edge(id = "1234", coordinates = { @Loc(value = COUNTER_CLOCKWISE_1),
+                            @Loc(value = COUNTER_CLOCKWISE_2) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA" }),
+                    @Edge(id = "1235", coordinates = { @Loc(value = COUNTER_CLOCKWISE_2),
+                            @Loc(value = COUNTER_CLOCKWISE_3) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA" }),
+                    @Edge(id = "1236", coordinates = { @Loc(value = COUNTER_CLOCKWISE_3),
+                            @Loc(value = CLOCKWISE_2) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA" }),
+                    @Edge(id = "1237", coordinates = { @Loc(value = CLOCKWISE_2),
+                            @Loc(value = CLOCKWISE_1) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA" }),
+                    @Edge(id = "1238", coordinates = { @Loc(value = COUNTER_CLOCKWISE_1),
+                            @Loc(value = CLOCKWISE_1) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA" }) })
+    private Atlas multiDirectionalRoundaboutAtlas;
+
+    public Atlas clockwiseRoundaboutLeftDrivingAtlas()
+    {
+        return this.clockwiseRoundaboutLeftDrivingAtlas;
+    }
+
+    public Atlas clockwiseRoundaboutRightDrivingAtlas()
+    {
+        return this.clockwiseRoundaboutRightDrivingAtlas;
+    }
+
+    public Atlas counterClockwiseRoundaboutLeftDrivingAtlas()
+    {
+        return this.counterClockwiseRoundaboutLeftDrivingAtlas;
+    }
+
+    public Atlas counterClockwiseRoundaboutRightDrivingAtlas()
+    {
+        return this.counterClockwiseRoundaboutRightDrivingAtlas;
+    }
+
+    public Atlas multiDirectionalRoundaboutAtlas()
+    {
+        return this.multiDirectionalRoundaboutAtlas;
+    }
+
+}


### PR DESCRIPTION
The enhancements made to the Intersecting Building check reworked the way an overlap was defined. Previously an overlap was defined by having one area completely surrounding or matching another. Now overlap is defined as areas of the exact same dimensions. Intersections where one area surrounds another are now defined as 'contains'. 
The configurable `overlap.lower.limit` was removed to accommodate this change. It is now a static `1.0`, or complete area match. 