### PR TITLE
Intersecting Building Check Enhancments Review

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -128,7 +128,6 @@
     }
   },
   "MalformedRoundaboutCheck" : {
-    "enabled": false,
     "traffic.countries.left":["AIA", "ATG", "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN", "BWA",
       "CCK", "COK", "CXR", "CYM", "CYP", "DMA", "FJI", "FLK", "GBR", "GGY", "GRD",
       "GUY", "HKG", "IDN", "IMN", "IND", "IRL", "JAM", "JEY", "JPN", "KEN", "KIR",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -107,6 +107,17 @@
       "tags":"highway"
     }
   },
+  "IntersectingBuildingCheck":
+  {
+    "intersection.lower.limit": 0.01,
+    "challenge": {
+      "description": "Buildings that intersect, contain, or overlap each other.",
+      "blurb": "Intersecting Buildings",
+      "instruction": "Correct intersecting buildings by moving them or dissolving one into another.",
+      "difficulty": "NORMAL",
+      "tags":"building"
+    }
+  },
   "InvalidTurnRestrictionCheck": {
     "challenge": {
       "description": "Tasks containing invalid turn restrictions",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -117,6 +117,7 @@
     }
   },
   "MalformedRoundaboutCheck" : {
+    "enabled": false,
     "traffic.countries.left":["AIA", "ATG", "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN", "BWA",
       "CCK", "COK", "CXR", "CYM", "CYP", "DMA", "FJI", "FLK", "GBR", "GGY", "GRD",
       "GUY", "HKG", "IDN", "IMN", "IND", "IRL", "JAM", "JEY", "JPN", "KEN", "KIR",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheck.java
@@ -14,6 +14,7 @@ import org.openstreetmap.atlas.geography.clipping.Clip;
 import org.openstreetmap.atlas.geography.clipping.Clip.ClipType;
 import org.openstreetmap.atlas.tags.BuildingTag;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.scalars.Surface;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +60,7 @@ public class IntersectingBuildingsCheck extends BaseCheck<String>
     private static final String UNIQUE_IDENTIFIER_FORMAT = "%s,%s";
 
     // Minimum intersection to be contained
-    private static final double overlapLowerLimit = 1.0;
+    private static final double OVERLAP_LOWER_LIMIT = 1.0;
 
     // Overlap below this limit is not considered to be intersecting
     private final double intersectionLowerLimit;
@@ -151,14 +152,13 @@ public class IntersectingBuildingsCheck extends BaseCheck<String>
             // Flag based on intersection type
             if (resultType == IntersectionType.OVERLAP)
             {
-                if (((Area) object).asPolygon().surface()
-                        .isLargerThan(otherBuilding.asPolygon().surface()))
+                final Surface objectAsSurface = ((Area) object).asPolygon().surface();
+                if (objectAsSurface.isLargerThan(otherBuilding.asPolygon().surface()))
                 {
                     flag.addObject(otherBuilding, this.getLocalizedInstruction(2,
                             object.getOsmIdentifier(), otherBuilding.getOsmIdentifier()));
                 }
-                else if (((Area) object).asPolygon().surface()
-                        .isLessThan(otherBuilding.asPolygon().surface()))
+                else if (objectAsSurface.isLessThan(otherBuilding.asPolygon().surface()))
                 {
                     flag.addObject(otherBuilding, this.getLocalizedInstruction(2,
                             otherBuilding.getOsmIdentifier(), object.getOsmIdentifier()));
@@ -203,8 +203,6 @@ public class IntersectingBuildingsCheck extends BaseCheck<String>
      *            {@link Polygon} to check for intersection
      * @param otherPolygon
      *            Another {@link Polygon} to check against for intersection
-     * @param areaSizeToCheck
-     *            Area size to decide if intersection area is big enough for overlap
      * @return {@link IntersectionType} between given {@link Polygon}s
      */
     private IntersectionType findIntersectionType(final Polygon polygon, final Polygon otherPolygon)
@@ -247,7 +245,7 @@ public class IntersectingBuildingsCheck extends BaseCheck<String>
         final long baselineArea = Math.min(polygon.surface().asDm7Squared(),
                 otherPolygon.surface().asDm7Squared());
         final double proportion = (double) intersectionArea / baselineArea;
-        if (proportion >= this.overlapLowerLimit)
+        if (proportion >= this.OVERLAP_LOWER_LIMIT)
         {
             return IntersectionType.OVERLAP;
         }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheck.java
@@ -50,7 +50,7 @@ public class IntersectingBuildingsCheck extends BaseCheck<String>
 
     // Default values for configurable settings
     private static final double INTERSECTION_LOWER_LIMIT_DEFAULT = 0.01;
-    private static final double OVERLAP_LOWER_LIMIT_DEFAULT = 0.90;
+    private static final double OVERLAP_LOWER_LIMIT_DEFAULT = 1.0;
 
     // Minimum number of points for a polygon
     private static final int MINIMUM_POINT_COUNT_FOR_POLYGON = 3;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheck.java
@@ -61,10 +61,7 @@ public class IntersectingBuildingsCheck extends BaseCheck<String>
     // Minimum intersection to be contained
     private static final double overlapLowerLimit = 1.0;
 
-    /*
-     * If the proportion of intersection compared to area of building is more than 2%, then we have
-     * a building intersection
-     */
+    // Overlap below this limit is not considered to be intersecting
     private final double intersectionLowerLimit;
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheck.java
@@ -152,17 +152,23 @@ public class IntersectingBuildingsCheck extends BaseCheck<String>
             // Flag based on intersection type
             if (resultType == IntersectionType.OVERLAP)
             {
+                // Get object as a Surface
                 final Surface objectAsSurface = ((Area) object).asPolygon().surface();
+                // If object is larger than otherBuilding, the instruction states object contains
+                // otherBuilding
                 if (objectAsSurface.isLargerThan(otherBuilding.asPolygon().surface()))
                 {
                     flag.addObject(otherBuilding, this.getLocalizedInstruction(2,
                             object.getOsmIdentifier(), otherBuilding.getOsmIdentifier()));
                 }
+                // If object is smaller than otherBuilding, the instruction states otherBuilding
+                // contains object
                 else if (objectAsSurface.isLessThan(otherBuilding.asPolygon().surface()))
                 {
                     flag.addObject(otherBuilding, this.getLocalizedInstruction(2,
                             otherBuilding.getOsmIdentifier(), object.getOsmIdentifier()));
                 }
+                // If object and otherBuilding are equal, the instruction states that they overlap
                 else
                 {
                     flag.addObject(otherBuilding, this.getLocalizedInstruction(0,

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheckTest.java
@@ -103,7 +103,7 @@ public class IntersectingBuildingsCheckTest
     }
 
     @Test
-    public void containsBuildingAtlas()
+    public void testContainsBuildingAtlas()
     {
         this.verifier.actual(this.setup.containsBuildingAtlas(), CHECK);
         this.verifier.verifyNotEmpty();

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheckTest.java
@@ -103,17 +103,16 @@ public class IntersectingBuildingsCheckTest
     }
 
     @Test
-    public void testSmallIntersectionBuildingsAtlasWithSmallOverlapLowerLimit()
+    public void containsBuildingAtlas()
     {
-        this.verifier.actual(this.setup.smallIntersectionBuildingsAtlas(),
-                new IntersectingBuildingsCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"IntersectingBuildingsCheck\": {\"intersection.lower.limit\": 0.01, \"overlap.lower.limit\": 0.10}}")));
+        this.verifier.actual(this.setup.containsBuildingAtlas(), CHECK);
         this.verifier.verifyNotEmpty();
         this.verifier.verifyExpectedSize(1);
         this.verifier.verify(flag ->
         {
             Assert.assertEquals(2, flag.getFlaggedObjects().size());
-            Assert.assertTrue(flag.getInstructions().contains("overlapped by another building"));
+            Assert.assertTrue(flag.getInstructions()
+                    .contains("Building (id=1234567) contains building (id=2234567)."));
         });
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsTestCaseRule.java
@@ -13,8 +13,8 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
  */
 public class IntersectingBuildingsTestCaseRule extends CoreTestRule
 {
-    private static final String TEST_1 = "47.620079, -122.206879";
-    private static final String TEST_2 = "47.619576, -122.206917";
+    private static final String TEST_1 = "47.620200, -122.206879";
+    private static final String TEST_2 = "47.619500, -122.206917";
     private static final String TEST_3 = "47.620094, -122.205856";
     private static final String TEST_4 = "47.619587, -122.205833";
     private static final String TEST_5 = "47.620087, -122.204948";
@@ -82,6 +82,15 @@ public class IntersectingBuildingsTestCaseRule extends CoreTestRule
                     @Loc(value = TEST_6), @Loc(value = TEST_2) }, tags = { "building=yes" }) })
     private Atlas severalDuplicateBuildingsAtlas;
 
+    @TestAtlas(areas = {
+            // a building
+            @Area(id = "1234567000000", coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                    @Loc(value = TEST_6), @Loc(value = TEST_5) }, tags = { "building=yes" }),
+            // another building with same footprint
+            @Area(id = "2234567000000", coordinates = { @Loc(value = TEST_7), @Loc(value = TEST_8),
+                    @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building=yes" }) })
+    private Atlas containsBuildingAtlas;
+
     public Atlas duplicateBuildingsAtlas()
     {
         return this.duplicateBuildingsAtlas;
@@ -110,5 +119,10 @@ public class IntersectingBuildingsTestCaseRule extends CoreTestRule
     public Atlas smallIntersectionBuildingsAtlas()
     {
         return this.smallIntersectionBuildingsAtlas;
+    }
+
+    public Atlas containsBuildingAtlas()
+    {
+        return this.containsBuildingAtlas;
     }
 }


### PR DESCRIPTION
The enhancements made to the Intersecting Building check reworked the way an overlap was defined. Previously an overlap was defined by having one area completely surrounding or matching another. Now overlap is defined as areas of the exact same dimensions. Intersections where one area surrounds another are now defined as 'contains'. 
The configurable `overlap.lower.limit` was removed to accommodate this change. It is now a static `1.0`, or complete area match. 