### PR TITLE
Sign Post Check Enhancement Review

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -61,14 +61,14 @@
       "difficulty": "EASY"
     }
   },
-  "DuplicatePointCheck": {
-    "challenge": {
-      "description": "Tasks contain node locations where duplicate points of interest are found.",
-      "blurb": "Duplicate Points",
-      "instruction": "Open your favorite editor and remove one or more of the duplicate points of interest until only one remains.",
-      "difficulty": "EASY"
-    }
-  },
+   "DuplicatePointCheck": {
+     "challenge": {
+       "description": "Tasks contain node locations where duplicate points of interest are found.",
+       "blurb": "Duplicate Points",
+       "instruction": "Open your favorite editor and remove one or more of the duplicate points of interest until only one remains.",
+       "difficulty": "EASY"
+     }
+   },
   "DuplicateWaysCheck": {
     "challenge": {
       "description": "Tasks contain Ways which have been partially or completely duplicated.",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -61,14 +61,14 @@
       "difficulty": "EASY"
     }
   },
-   "DuplicatePointCheck": {
-     "challenge": {
-       "description": "Tasks contain node locations where duplicate points of interest are found.",
-       "blurb": "Duplicate Points",
-       "instruction": "Open your favorite editor and remove one or more of the duplicate points of interest until only one remains.",
-       "difficulty": "EASY"
-     }
-   },
+  "DuplicatePointCheck": {
+    "challenge": {
+      "description": "Tasks contain node locations where duplicate points of interest are found.",
+      "blurb": "Duplicate Points",
+      "instruction": "Open your favorite editor and remove one or more of the duplicate points of interest until only one remains.",
+      "difficulty": "EASY"
+    }
+  },
   "DuplicateWaysCheck": {
     "challenge": {
       "description": "Tasks contain Ways which have been partially or completely duplicated.",
@@ -243,18 +243,25 @@
     }
   },
   "SignPostCheck": {
-    "enabled": false,
     "linkLength": {
       "minimum.meters": 50.0
     },
+    "ramp":
+    {
+      "max.edges":10,
+      "filter":"highway->motorway_link,trunk_link"
+    },
+    "source.filter":"highway->motorway,trunk",
+    "destination_tag.filter":"destination->*|destination:ref->*|destination:street->*",
+    "arterial.minimum":"RESIDENTIAL",
     "challenge": {
       "description": "Tasks contain nodes where sign post tagging could be missing.  In particular it looks for motorway and trunk ways which have a link edge exiting them.  A task is generated if either the connecting node is missing the motorway_junction tag or the exiting segment is missing the destination tag.",
       "blurb": "Missing sign post tags",
       "instruction": "Either add the missing motorway_junction tag to the identified node and / or the destination tag to the exiting link segment.",
       "difficulty": "NORMAL",
-      "defaultPriority": "MEDIUM"
-    },
-    "tags":"highway"
+      "defaultPriority": "MEDIUM",
+      "tags":"highway"
+    }
   },
   "WaterbodyAndIslandSizeCheck": {
     "surface":{

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
@@ -10,7 +10,6 @@ import org.apache.directory.api.util.Strings;
 import org.openstreetmap.atlas.checks.atlas.predicates.TypePredicates;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
-import org.openstreetmap.atlas.geography.Heading;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
@@ -206,9 +205,7 @@ public class SignPostCheck extends BaseCheck<String>
 
         // Go back and collect edges
         final List<Edge> endEdges = new ArrayList<>();
-        // Check that we are not over the max and the edge haas a heading
-        final Optional<Heading> initialHeading = finalEdge.asPolyLine().initialHeading();
-        if (count < maxEdgeCount && initialHeading.isPresent())
+        if (count < maxEdgeCount)
         {
             // Collect in edges and make sure the list is not empty
             final Set<Edge> inEdges = finalEdge.inEdges();

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
@@ -201,17 +201,15 @@ public class SignPostCheck extends BaseCheck<String>
      */
     private List<Edge> findFirstRampEdge(final Edge finalEdge, final long maxEdgeCount)
     {
-        final int count = 0;
-
         // Go back and collect edges
         final List<Edge> endEdges = new ArrayList<>();
-        if (count < maxEdgeCount)
+        if (maxEdgeCount > 0)
         {
             // Collect in edges and make sure the list is not empty
             final Set<Edge> inEdges = finalEdge.inEdges();
             if (!inEdges.isEmpty())
             {
-                // Check each in edge
+                // Check each inEdge
                 for (final Edge nextEdge : inEdges)
                 {
                     // See if it is connected to a source edge
@@ -231,8 +229,8 @@ public class SignPostCheck extends BaseCheck<String>
                     // Recurse through inEdges if this edge is not the other side of a bidirectional
                     // way
                     else if (nextEdge.highwayTag().isIdenticalClassification(finalEdge.highwayTag())
-                            && !(finalEdge.getMasterEdgeIdentifier() == nextEdge
-                                    .getMasterEdgeIdentifier()))
+                            && finalEdge.getMasterEdgeIdentifier() != nextEdge
+                                    .getMasterEdgeIdentifier())
                     {
                         endEdges.addAll(findFirstRampEdge(nextEdge, maxEdgeCount - 1));
                     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.checks.validation.linear.edges;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -18,7 +19,6 @@ import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.tags.filters.TaggableFilter;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
-import org.openstreetmap.atlas.utilities.scalars.Angle;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 /**
@@ -27,7 +27,7 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
  * Once ramps are identified and filtered, a flag is thrown if one or both of the following
  * conditions are met.
  * <p>
- * 1) The starting node for the ramp is missing the highway=motorway_junction tag<br>
+ * 1) The starting node for an off ramp is missing the highway=motorway_junction tag<br>
  * 2) The ramp road is missing the destination tag<br>
  * <p>
  * If either of these cases is true and ramp is over a certain length then a flag is created.
@@ -50,11 +50,14 @@ public class SignPostCheck extends BaseCheck<String>
     // Default values for configurable settings
     private static final double DISTANCE_MINIMUM_METERS_DEFAULT = 50;
     private static final String SOURCE_EDGE_FILTER_DEFAULT = "highway->motorway,trunk";
-    private static final String RAMP_FILTER_DEFAULT = "highway->motorway,motorway_link,trunk,trunk_link";
-    private static final double RAMP_ANGLE_DIFFERENCE_DEFAULT = 30;
+    private static final String RAMP_FILTER_DEFAULT = "highway->motorway_link,trunk_link";
+    private static final String DESTINATION_TAG_FILTER_DEFAULT = "destination->*|destination:ref->*|destination:street->*";
+    private static final String ARTERIAL_MINIMUM_DEFAULT = HighwayTag.RESIDENTIAL.toString();
 
     // Maximum number of hops while collecting ramp edges
-    private static final int MAX_EDGE_COUNT_FOR_RAMP = 5;
+    private static final long MAX_EDGE_COUNT_FOR_RAMP_DEFAULT = 5;
+
+    private final long maxEdgeCountForRamp;
 
     // The minimum link length to examine.
     private final Distance minimumLinkLength;
@@ -65,11 +68,14 @@ public class SignPostCheck extends BaseCheck<String>
     // A filter to filter ramp edges
     private final TaggableFilter rampEdgeFilter;
 
+    // A filter for the variations of the destination tag
+    private final TaggableFilter destinationTagFilter;
+
     // A tag to differentiate ramps from roads with the same classification
     private final String rampDifferentiatorTag;
 
-    // Maximum angle difference between ramp edges
-    private final Angle rampAngleDifference;
+    // The minimum highway tag for an arterial road
+    private final HighwayTag arterialMinimum;
 
     /**
      * The default constructor that must be supplied. The Atlas Checks framework will generate the
@@ -83,16 +89,21 @@ public class SignPostCheck extends BaseCheck<String>
     {
         super(configuration);
 
+        this.maxEdgeCountForRamp = configurationValue(configuration, "ramp.max.edges",
+                MAX_EDGE_COUNT_FOR_RAMP_DEFAULT);
         this.minimumLinkLength = configurationValue(configuration, "linkLength.minimum.meters",
                 DISTANCE_MINIMUM_METERS_DEFAULT, Distance::meters);
         this.sourceEdgeFilter = configurationValue(configuration, "source.filter",
                 SOURCE_EDGE_FILTER_DEFAULT, value -> new TaggableFilter(value));
         this.rampEdgeFilter = configurationValue(configuration, "ramp.filter", RAMP_FILTER_DEFAULT,
                 value -> new TaggableFilter(value));
+        this.destinationTagFilter = configurationValue(configuration, "destination_tag.filter",
+                DESTINATION_TAG_FILTER_DEFAULT, value -> new TaggableFilter(value));
         this.rampDifferentiatorTag = configurationValue(configuration, "ramp.differentiator.tag",
                 null);
-        this.rampAngleDifference = configurationValue(configuration,
-                "ramp.angle.difference.degrees", RAMP_ANGLE_DIFFERENCE_DEFAULT, Angle::degrees);
+        this.arterialMinimum = Enum.valueOf(HighwayTag.class,
+                configurationValue(configuration, "arterial.minimum", ARTERIAL_MINIMUM_DEFAULT)
+                        .toUpperCase());
     }
 
     /**
@@ -138,7 +149,7 @@ public class SignPostCheck extends BaseCheck<String>
                     }
 
                     // Check if edge is missing destination tag
-                    if (!outEdge.getTag(DestinationTag.KEY).isPresent())
+                    if (!destinationTagFilter.test(outEdge))
                     {
                         flag.addInstruction(this.getLocalizedInstruction(1,
                                 outEdge.getOsmIdentifier(), OFF_RAMP_KEY, DestinationTag.KEY));
@@ -152,24 +163,18 @@ public class SignPostCheck extends BaseCheck<String>
                 .forEach(inEdge ->
                 {
                     // Find the source of in-ramp
-                    final Edge rampEdge = findFirstRampEdge(inEdge);
+                    final List<Edge> rampEdgeList = findFirstRampEdge(inEdge, maxEdgeCountForRamp);
 
-                    // Check to see if start node is missing junction tag
-                    final Node start = rampEdge.start();
-                    if (!Validators.isOfType(start, HighwayTag.class, HighwayTag.MOTORWAY_JUNCTION))
+                    for (final Edge rampEdge : rampEdgeList)
                     {
-                        flag.addInstruction(this.getLocalizedInstruction(0,
-                                start.getOsmIdentifier(), String.format("%s=%s", HighwayTag.KEY,
-                                        HighwayTag.MOTORWAY_JUNCTION.getTagValue())));
-                        flag.addObject(start);
-                    }
 
-                    // Check if edge is missing destination tag
-                    if (!rampEdge.getTag(DestinationTag.KEY).isPresent())
-                    {
-                        flag.addInstruction(this.getLocalizedInstruction(1,
-                                rampEdge.getOsmIdentifier(), ON_RAMP_KEY, DestinationTag.KEY));
-                        flag.addObject(rampEdge);
+                        // Check if edge is missing destination tag
+                        if (!destinationTagFilter.test(rampEdge))
+                        {
+                            flag.addInstruction(this.getLocalizedInstruction(1,
+                                    rampEdge.getOsmIdentifier(), ON_RAMP_KEY, DestinationTag.KEY));
+                            flag.addObject(rampEdge);
+                        }
                     }
                 });
 
@@ -195,53 +200,51 @@ public class SignPostCheck extends BaseCheck<String>
      *            {@link Edge} that is the last/final piece of the ramp
      * @return {@link Edge} that possibly is the first {@link Edge} forming the ramp
      */
-    private Edge findFirstRampEdge(final Edge finalEdge)
+    private List<Edge> findFirstRampEdge(final Edge finalEdge, final long maxEdgeCount)
     {
-        int count = 0;
+        final int count = 0;
 
         // Go back and collect edges
-        Edge nextEdge = finalEdge;
-        while (count < MAX_EDGE_COUNT_FOR_RAMP)
+        final List<Edge> endEdges = new ArrayList<>();
+        // Check that we are not over the max and the edge haas a heading
+        final Optional<Heading> initialHeading = finalEdge.asPolyLine().initialHeading();
+        if (count < maxEdgeCount && initialHeading.isPresent())
         {
-            count++;
-
-            // Break if edge has no heading
-            final Optional<Heading> initialHeading = nextEdge.asPolyLine().initialHeading();
-            if (!initialHeading.isPresent())
+            // Collect in edges and make sure the list is not empty
+            final Set<Edge> inEdges = finalEdge.inEdges();
+            if (!inEdges.isEmpty())
             {
-                break;
+                // Check each in edge
+                for (final Edge nextEdge : inEdges)
+                {
+                    // See if it is connected to a source edge
+                    if (this.sourceEdgeFilter.test(nextEdge))
+                    {
+                        endEdges.clear();
+                        return endEdges;
+                    }
+                    // See if it is an arterial
+                    if (!this.rampEdgeFilter.test(nextEdge) && HighwayTag.highwayTag(nextEdge)
+                            .orElse(HighwayTag.NO).isMoreImportantThanOrEqualTo(arterialMinimum))
+                    {
+                        endEdges.clear();
+                        endEdges.add(finalEdge);
+                        return endEdges;
+                    }
+                    // Recurse through inEdges if not the other split of a way
+                    else if (nextEdge.highwayTag().isIdenticalClassification(finalEdge.highwayTag())
+                            && !(finalEdge.getMasterEdgeIdentifier() == nextEdge
+                                    .getMasterEdgeIdentifier()))
+                    {
+                        endEdges.addAll(findFirstRampEdge(nextEdge, maxEdgeCount - 1));
+                    }
+                }
+                return endEdges;
             }
-
-            // Collect in edges and make sure there is not more than one
-            final Set<Edge> inEdges = nextEdge.inEdges();
-            if (inEdges.isEmpty() || inEdges.size() > 1)
-            {
-                break;
-            }
-
-            // Find the edge that precedes nextEdge
-            final HighwayTag highwayTag = nextEdge.highwayTag();
-            final Edge precedingEdge = inEdges.iterator().next();
-
-            // Ignore if edge has a different classification
-            if (!highwayTag.isIdenticalClassification(precedingEdge.highwayTag()))
-            {
-                break;
-            }
-
-            // Break if given edge has no heading
-            final Optional<Heading> finalHeading = precedingEdge.asPolyLine().finalHeading();
-            if (!finalHeading.isPresent() || initialHeading.get().asPositiveAngle()
-                    .difference(finalHeading.get().asPositiveAngle())
-                    .isGreaterThan(this.rampAngleDifference))
-            {
-                break;
-            }
-
-            nextEdge = precedingEdge;
         }
-
-        return nextEdge;
+        endEdges.clear();
+        endEdges.add(finalEdge);
+        return endEdges;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
@@ -231,7 +231,8 @@ public class SignPostCheck extends BaseCheck<String>
                         endEdges.add(finalEdge);
                         return endEdges;
                     }
-                    // Recurse through inEdges if not the other split of a way
+                    // Recurse through inEdges if this edge is not the other side of a bidirectional
+                    // way
                     else if (nextEdge.highwayTag().isIdenticalClassification(finalEdge.highwayTag())
                             && !(finalEdge.getMasterEdgeIdentifier() == nextEdge
                                     .getMasterEdgeIdentifier()))

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheckTestRule.java
@@ -396,6 +396,93 @@ public class SignPostCheckTestRule extends CoreTestRule
                                     "destination=somewhere" }) })
     private Atlas motorwayMotorwayLinkWithJunctionAndDestinationAtlas;
 
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3), tags = {
+                            "highway=motorway_junction" }),
+                    @Node(coordinates = @Loc(value = HIGHWAY_5)),
+                    @Node(coordinates = @Loc(value = LINK_1)),
+                    @Node(coordinates = @Loc(value = LINK_4)) },
+            // edges
+            edges = {
+                    @Edge(coordinates = { @Loc(value = HIGHWAY_1), @Loc(value = HIGHWAY_2),
+                            @Loc(value = HIGHWAY_3) }, tags = { "highway=motorway" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_4),
+                            @Loc(value = HIGHWAY_5) }, tags = { "highway=motorway" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = LINK_1),
+                            @Loc(value = LINK_2), @Loc(value = LINK_3),
+                            @Loc(value = LINK_4) }, tags = { "highway=motorway_link",
+                                    "destination:ref=somewhere" }) })
+    private Atlas motorwayMotorwayLinkWithJunctionAndDestinationRefAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_2)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_4)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_5)),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_1)),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_2)),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_3)),
+                    @Node(coordinates = @Loc(value = LINK_2)),
+                    @Node(coordinates = @Loc(value = LINK_3)),
+                    @Node(coordinates = @Loc(value = LINK_4)),
+                    @Node(coordinates = @Loc(value = LINK2_1)) },
+            // edges
+            edges = {
+                    @Edge(coordinates = { @Loc(value = HIGHWAY_5), @Loc(value = HIGHWAY_4),
+                            @Loc(value = HIGHWAY_3) }, tags = { "highway=motorway" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_2),
+                            @Loc(value = HIGHWAY_1) }, tags = { "highway=motorway" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY2_3), @Loc(value = HIGHWAY2_2),
+                            @Loc(value = LINK_4) }, tags = { "highway=primary" }),
+                    @Edge(coordinates = { @Loc(value = LINK_4), @Loc(value = HIGHWAY2_1) }, tags = {
+                            "highway=primary" }),
+                    @Edge(coordinates = { @Loc(value = LINK_2), @Loc(value = HIGHWAY_3) }, tags = {
+                            "highway=motorway_link" }),
+                    @Edge(coordinates = { @Loc(value = LINK_4), @Loc(value = LINK_3),
+                            @Loc(value = LINK_2) }, tags = { "highway=motorway_link" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY2_2), @Loc(value = LINK2_1),
+                            @Loc(value = LINK_2) }, tags = { "highway=motorway_link" }) })
+    private Atlas motorwayMotorwayLinkBranchMissingDestinationAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_2)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_4)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_5), tags = {
+                            "highway=motorway_junction" }),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_1)),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_2)),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_3)),
+                    @Node(coordinates = @Loc(value = LINK_2)),
+                    @Node(coordinates = @Loc(value = LINK_3)),
+                    @Node(coordinates = @Loc(value = LINK_4)),
+                    @Node(coordinates = @Loc(value = LINK2_1)) },
+            // edges
+            edges = {
+                    @Edge(coordinates = { @Loc(value = HIGHWAY_5), @Loc(value = HIGHWAY_4),
+                            @Loc(value = HIGHWAY_3) }, tags = { "highway=motorway" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_2),
+                            @Loc(value = HIGHWAY_1) }, tags = { "highway=motorway" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY2_3), @Loc(value = HIGHWAY2_2),
+                            @Loc(value = LINK_4) }, tags = { "highway=primary" }),
+                    @Edge(coordinates = { @Loc(value = LINK_4), @Loc(value = HIGHWAY2_1) }, tags = {
+                            "highway=primary" }),
+                    @Edge(coordinates = { @Loc(value = LINK_3), @Loc(value = LINK_2),
+                            @Loc(value = HIGHWAY_3) }, tags = { "highway=motorway_link" }),
+                    @Edge(coordinates = { @Loc(value = LINK_4), @Loc(value = LINK_3) }, tags = {
+                            "highway=motorway_link" }),
+                    @Edge(coordinates = { @Loc(value = LINK_3), @Loc(value = LINK_4) }, tags = {
+                            "highway=motorway_link" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY_5), @Loc(value = LINK_3) }, tags = {
+                            "highway=motorway_link", "destination=somewhere" }) })
+    private Atlas motorwayMotorwayLinkTwoWayBranchMissingDestinationAtlas;
+
     public Atlas motorroadPrimaryLinkMissingJunctionAndDestinationAtlas()
     {
         return this.motorroadPrimaryLinkMissingJunctionAndDestinationAtlas;
@@ -419,6 +506,11 @@ public class SignPostCheckTestRule extends CoreTestRule
     public Atlas motorwayMotorwayLinkWithJunctionAndDestinationAtlas()
     {
         return this.motorwayMotorwayLinkWithJunctionAndDestinationAtlas;
+    }
+
+    public Atlas motorwayMotorwayLinkWithJunctionAndDestinationRefAtlas()
+    {
+        return this.motorwayMotorwayLinkWithJunctionAndDestinationRefAtlas;
     }
 
     public Atlas motorwayMultipleLinksMissingJunctionAndDestinationAtlas()
@@ -494,5 +586,15 @@ public class SignPostCheckTestRule extends CoreTestRule
     public Atlas unclassifiedPrimaryLinkMissingJunctionAndDestinationAtlas()
     {
         return this.unclassifiedPrimaryLinkMissingJunctionAndDestinationAtlas;
+    }
+
+    public Atlas motorwayMotorwayLinkBranchMissingDestinationAtlas()
+    {
+        return this.motorwayMotorwayLinkBranchMissingDestinationAtlas;
+    }
+
+    public Atlas motorwayMotorwayLinkTwoWayBranchMissingDestinationAtlas()
+    {
+        return this.motorwayMotorwayLinkTwoWayBranchMissingDestinationAtlas;
     }
 }


### PR DESCRIPTION
This enhancement changes default configurable values, removes the `motorway_junction` test from on ramps, reworks the `findFirstRampEdge` method, and enables this check.  

The new default values create less errors from overlapping values.

The `motorway_junction` test was removed from on ramps because they do not require a node with that tag: [OSM wiki: motorway_junction](https://wiki.openstreetmap.org/wiki/Tag:highway=motorway_junction)

`findFirstRampEdge` no longer uses heading to determine connection. It now uses a recursive search for arterial roads based on the configurable filters and minimum arterial classification. 

This check was disabled via the configuration. The configuration.json in this PR re-enables it. 