### PR TITLE
Invalid Lanes Tag Check Review

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -61,14 +61,14 @@
       "difficulty": "EASY"
     }
   },
-  "DuplicatePointCheck": {
-    "challenge": {
-      "description": "Tasks contain node locations where duplicate points of interest are found.",
-      "blurb": "Duplicate Points",
-      "instruction": "Open your favorite editor and remove one or more of the duplicate points of interest until only one remains.",
-      "difficulty": "EASY"
-    }
-  },
+   "DuplicatePointCheck": {
+     "challenge": {
+       "description": "Tasks contain node locations where duplicate points of interest are found.",
+       "blurb": "Duplicate Points",
+       "instruction": "Open your favorite editor and remove one or more of the duplicate points of interest until only one remains.",
+       "difficulty": "EASY"
+     }
+   },
   "DuplicateWaysCheck": {
     "challenge": {
       "description": "Tasks contain Ways which have been partially or completely duplicated.",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -61,14 +61,14 @@
       "difficulty": "EASY"
     }
   },
-   "DuplicatePointCheck": {
-     "challenge": {
-       "description": "Tasks contain node locations where duplicate points of interest are found.",
-       "blurb": "Duplicate Points",
-       "instruction": "Open your favorite editor and remove one or more of the duplicate points of interest until only one remains.",
-       "difficulty": "EASY"
-     }
-   },
+  "DuplicatePointCheck": {
+    "challenge": {
+      "description": "Tasks contain node locations where duplicate points of interest are found.",
+      "blurb": "Duplicate Points",
+      "instruction": "Open your favorite editor and remove one or more of the duplicate points of interest until only one remains.",
+      "difficulty": "EASY"
+    }
+  },
   "DuplicateWaysCheck": {
     "challenge": {
       "description": "Tasks contain Ways which have been partially or completely duplicated.",
@@ -105,6 +105,16 @@
         "rules":["highway=primary","highway=primary_link","highway=secondary","highway=secondary_link"]
       },
       "tags":"highway"
+    }
+  },
+  "InvalidLanesTagCheck": {
+    "lanes.filter": "Lanes->1,1.5,2,3,4,5,6,7,8,9,10",
+    "challenge":{
+      "description":"Tasks contain invalid values for the lanes tag.",
+      "blurb":"Invalid Lanes Tags",
+      "instruction":"Change the lanes tag to have a valid and representative value.",
+      "difficulty":"EASY",
+      "tags":"lanes,highway"
     }
   },
   "InvalidTurnRestrictionCheck": {

--- a/docs/checks/invalidLanesTagCheck.md
+++ b/docs/checks/invalidLanesTagCheck.md
@@ -80,7 +80,9 @@ private boolean partOfTollBooth(final AtlasObject object)
             }
             for (final Edge edge : polledEdge.connectedEdges())
             {
-                if (!connectedEdges.contains(edge.getIdentifier()) && !lanesFilter.test(edge))
+                if (!connectedEdges.contains(edge.getIdentifier())
+                        && Validators.hasValuesFor(edge, LanesTag.class)
+                        && !this.lanesFilter.test(edge))
                 {
                     toProcess.add(edge);
                     connectedEdges.add(edge.getIdentifier());

--- a/docs/checks/invalidLanesTagCheck.md
+++ b/docs/checks/invalidLanesTagCheck.md
@@ -5,7 +5,8 @@ This check flags roads that have invalid `lanes` tag values.
 Valid values are configurable. The defaults are:  
 `1,1.5,2,3,4,5,6,7,8,9,10`
 
-In OSM, generally, lanes values greater than 10 are incorrect, and no lanes values should have special characters with the exception of 1.5. The lanes value 1.5 is valid, due to people often using this value to signify a narrow two lane road.
+In OSM, generally, lanes values greater than 10 are incorrect, and no lanes values should have special characters with the exception of 1.5. The lanes value 1.5 is valid, due to people often using this value to signify a narrow two lane road.  
+One exception, that is handled, is when there is a toll booth. 
 
 #### Live Examples
 
@@ -32,19 +33,68 @@ Our first goal is to validate the incoming Atlas object. Valid features for this
     }
 ```
 
-The valid objects are then tested against the list of valid `lanes` tag values, and flagged if their value is invalid.
+The valid objects are then tested against the list of valid `lanes` tag values, and checked for toll booths (see below).  They are flagged if both these items are false.
 
 ```java
 @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
-        if (!this.lanesFilter.test(object))
+        if (!this.lanesFilter.test(object)  && !partOfTollBooth(object))
         {
             this.markAsFlagged(((Edge) object).getOsmIdentifier());
             return Optional.of(this.createFlag(object,
                     this.getLocalizedInstruction(0, object.getOsmIdentifier())));
         }
         return Optional.empty();
+    }
+```
+
+The test for toll booths checks all connected Edges with invalid `lanes` tag values. This is to ensure the whole toll plaza is properly evaluated.  
+If a toll booth is found, all the connected Edges are marked as checked. This prevents unnecessary rechecking of the same toll plaza later. 
+
+```java
+private boolean partOfTollBooth(final AtlasObject object)
+    {
+        // Connected edges with lanes tag values not in the lanesFilter
+        final HashSet<Long> connectedEdges = new HashSet<>();
+        // Que of edges to be processed
+        final ArrayDeque<Edge> toProcess = new ArrayDeque<>();
+        boolean tollBooth = false;
+        Edge polledEdge;
+
+        // Add original edge
+        connectedEdges.add(object.getIdentifier());
+        toProcess.add((Edge) object);
+
+        // Get all connected edges with lanes tag values not in the lanesFilter and check for toll
+        // booths
+        while (!toProcess.isEmpty())
+        {
+            polledEdge = toProcess.poll();
+            for (final Node node : polledEdge.connectedNodes())
+            {
+                if (Validators.isOfType(node, BarrierTag.class, BarrierTag.TOLL_BOOTH))
+                {
+                    tollBooth = true;
+                }
+            }
+            for (final Edge edge : polledEdge.connectedEdges())
+            {
+                if (!connectedEdges.contains(edge.getIdentifier()) && !lanesFilter.test(edge))
+                {
+                    toProcess.add(edge);
+                    connectedEdges.add(edge.getIdentifier());
+                }
+            }
+        }
+
+        // Add to the global set so we don't process items twice unnecessarily
+        if (tollBooth)
+        {
+            this.isChecked.addAll(connectedEdges);
+        }
+
+        return tollBooth;
     }
 ```
 

--- a/docs/checks/invalidLanesTagCheck.md
+++ b/docs/checks/invalidLanesTagCheck.md
@@ -20,7 +20,7 @@ In [Atlas](https://github.com/osmlab/atlas), OSM elements are represented as Edg
 Our first goal is to validate the incoming Atlas object. Valid features for this check will satisfy the following conditions:
 
 * Is an Edge
-* Has a `highway` tag
+* Has a `highway` tag that is car navigable
 * Has a `lanes` tag
 * Does not have a valid `lanes` tag
 

--- a/docs/checks/invalidLanesTagCheck.md
+++ b/docs/checks/invalidLanesTagCheck.md
@@ -28,7 +28,7 @@ Our first goal is to validate the incoming Atlas object. Valid features for this
     {
         return Validators.hasValuesFor(object, LanesTag.class)
                 && HighwayTag.highwayTag(object).isPresent() && object instanceof Edge
-                && !this.isFlagged(((Edge) object).getMasterEdgeIdentifier());
+                && !this.isFlagged(((Edge) object).getOsmIdentifier());
     }
 ```
 
@@ -40,7 +40,7 @@ The valid objects are then tested against the list of valid `lanes` tag values, 
     {
         if (!this.lanesFilter.test(object))
         {
-            this.markAsFlagged(((Edge) object).getMasterEdgeIdentifier());
+            this.markAsFlagged(((Edge) object).getOsmIdentifier());
             return Optional.of(this.createFlag(object,
                     this.getLocalizedInstruction(0, object.getOsmIdentifier())));
         }

--- a/docs/checks/invalidLanesTagCheck.md
+++ b/docs/checks/invalidLanesTagCheck.md
@@ -1,0 +1,52 @@
+# Invalid Lanes Tag Check 
+
+This check flags roads that have invalid `lanes` tag values.
+
+Valid values are configurable. The defaults are:  
+`1,1.5,2,3,4,5,6,7,8,9,10`
+
+In OSM, generally, lanes values greater than 10 are incorrect, and no lanes values should have special characters with the exception of 1.5. The lanes value 1.5 is valid, due to people often using this value to signify a narrow two lane road.
+
+#### Live Examples
+
+1. The way [id:313769043](https://www.openstreetmap.org/way/313769043) has an invalid `lanes` tag value of `2;1`. `lanes` tag values must be numeric. 
+2. The way [id:58693335](https://www.openstreetmap.org/way/58693335) has an invalid `lanes` tag value of `20`. Satellite imagery shows this to be a misrepresentation of reality.
+
+#### Code Review
+
+In [Atlas](https://github.com/osmlab/atlas), OSM elements are represented as Edges, Points, Lines, Nodes & Relations; in our case, we’re are looking at [Edges](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java).
+
+Our first goal is to validate the incoming Atlas object. Valid features for this check will satisfy the following conditions:
+
+* Is an Edge
+* Has a `highway` tag
+* Has a `lanes` tag
+
+```java
+@Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return Validators.hasValuesFor(object, LanesTag.class)
+                && HighwayTag.highwayTag(object).isPresent() && object instanceof Edge
+                && !this.isFlagged(((Edge) object).getMasterEdgeIdentifier());
+    }
+```
+
+The valid objects are then tested against the list of valid `lanes` tag values, and flagged if their value is invalid.
+
+```java
+@Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        if (!this.lanesFilter.test(object))
+        {
+            this.markAsFlagged(((Edge) object).getMasterEdgeIdentifier());
+            return Optional.of(this.createFlag(object,
+                    this.getLocalizedInstruction(0, object.getOsmIdentifier())));
+        }
+        return Optional.empty();
+    }
+```
+
+To learn more about the code, please look at the comments in the source code for the check.  
+[InvalidLanesTagCheck](../../src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java)

--- a/docs/checks/invalidLanesTagCheck.md
+++ b/docs/checks/invalidLanesTagCheck.md
@@ -57,7 +57,7 @@ private boolean partOfTollBooth(final AtlasObject object)
     {
         // Connected edges with lanes tag values not in the lanesFilter
         final HashSet<Long> connectedEdges = new HashSet<>();
-        // Que of edges to be processed
+        // Queue of edges to be processed
         final ArrayDeque<Edge> toProcess = new ArrayDeque<>();
         boolean tollBooth = false;
         Edge polledEdge;

--- a/docs/checks/invalidLanesTagCheck.md
+++ b/docs/checks/invalidLanesTagCheck.md
@@ -71,11 +71,15 @@ private boolean partOfTollBooth(final AtlasObject object)
         while (!toProcess.isEmpty())
         {
             polledEdge = toProcess.poll();
-            for (final Node node : polledEdge.connectedNodes())
+            if (!tollBooth)
             {
-                if (Validators.isOfType(node, BarrierTag.class, BarrierTag.TOLL_BOOTH))
+                for (final Node node : polledEdge.connectedNodes())
                 {
-                    tollBooth = true;
+                    if (Validators.isOfType(node, BarrierTag.class, BarrierTag.TOLL_BOOTH))
+                    {
+                        tollBooth = true;
+                        break;
+                    }
                 }
             }
             for (final Edge edge : polledEdge.connectedEdges())

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
@@ -131,7 +131,9 @@ public class InvalidLanesTagCheck extends BaseCheck
             }
             for (final Edge edge : polledEdge.connectedEdges())
             {
-                if (!connectedEdges.contains(edge.getIdentifier()) && !lanesFilter.test(edge))
+                if (!connectedEdges.contains(edge.getIdentifier())
+                        && Validators.hasValuesFor(edge, LanesTag.class)
+                        && !this.lanesFilter.test(edge))
                 {
                     toProcess.add(edge);
                     connectedEdges.add(edge.getIdentifier());

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
@@ -26,12 +26,10 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  */
 public class InvalidLanesTagCheck extends BaseCheck
 {
-
     private static final long serialVersionUID = -1459761692833694715L;
 
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
             .asList("Way {0,number,#} has an invalid lanes value.");
-
     // Valid values of the lanes OSM key
     private static final String LANES_FILTER_DEFAULT = "Lanes->1,1.5,2,3,4,5,6,7,8,9,10";
     private final TaggableFilter lanesFilter;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
@@ -64,7 +64,8 @@ public class InvalidLanesTagCheck extends BaseCheck
     {
         return Validators.hasValuesFor(object, LanesTag.class)
                 && HighwayTag.isCarNavigableHighway(object) && object instanceof Edge
-                && !this.lanesFilter.test(object) && !this.isFlagged(object.getOsmIdentifier());
+                && ((Edge) object).isMasterEdge() && !this.lanesFilter.test(object)
+                && !this.isFlagged(object.getOsmIdentifier());
     }
 
     /**
@@ -152,7 +153,8 @@ public class InvalidLanesTagCheck extends BaseCheck
             polledEdge = toProcess.poll();
             for (final Edge edge : polledEdge.connectedEdges())
             {
-                if (!connectedEdges.contains(edge) && Validators.hasValuesFor(edge, LanesTag.class)
+                if (!connectedEdges.contains(edge) && ((Edge) object).isMasterEdge()
+                        && Validators.hasValuesFor(edge, LanesTag.class)
                         && HighwayTag.isCarNavigableHighway(edge) && !this.lanesFilter.test(edge))
                 {
                     toProcess.add(edge);

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
@@ -1,0 +1,89 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.LanesTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.tags.filters.TaggableFilter;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * Flags {@link Edge}s that have the {@code highway} tag and a {@code lanes} tag with an invalid
+ * value. The valid {@code lanes} values are configurable.
+ *
+ * @author bbreithaupt
+ */
+public class InvalidLanesTagCheck extends BaseCheck
+{
+
+    private static final long serialVersionUID = -1459761692833694715L;
+
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
+            .asList("Way {0,number,#} has an invalid lanes value.");
+
+    private static final String LANES_FILTER_DEFAULT = "Lanes->1,1.5,2,3,4,5,6,7,8,9,10";
+
+    private final TaggableFilter lanesFilter;
+
+    /**
+     * The default constructor that must be supplied. The Atlas Checks framework will generate the
+     * checks with this constructor, supplying a configuration that can be used to adjust any
+     * parameters that the check uses during operation.
+     *
+     * @param configuration
+     *            the JSON configuration for this check
+     */
+    public InvalidLanesTagCheck(final Configuration configuration)
+    {
+        super(configuration);
+        this.lanesFilter = (TaggableFilter) configurationValue(configuration, "lanes.filter",
+                LANES_FILTER_DEFAULT, value -> new TaggableFilter(value.toString()));
+    }
+
+    /**
+     * This function will validate if the supplied atlas object is valid for the check.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return {@code true} if this object should be checked
+     */
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return Validators.hasValuesFor(object, LanesTag.class)
+                && HighwayTag.highwayTag(object).isPresent() && object instanceof Edge
+                && !this.isFlagged(((Edge) object).getOsmIdentifier());
+    }
+
+    /**
+     * This is the actual function that will check to see whether the object needs to be flagged.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return an optional {@link CheckFlag} object that
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        if (!this.lanesFilter.test(object))
+        {
+            this.markAsFlagged(((Edge) object).getOsmIdentifier());
+            return Optional.of(this.createFlag(object,
+                    this.getLocalizedInstruction(0, object.getOsmIdentifier())));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
@@ -108,7 +108,7 @@ public class InvalidLanesTagCheck extends BaseCheck
     {
         // Connected edges with lanes tag values not in the lanesFilter
         final HashSet<Long> connectedEdges = new HashSet<>();
-        // Que of edges to be processed
+        // Queue of edges to be processed
         final ArrayDeque<Edge> toProcess = new ArrayDeque<>();
         boolean tollBooth = false;
         Edge polledEdge;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
@@ -120,11 +120,15 @@ public class InvalidLanesTagCheck extends BaseCheck
         while (!toProcess.isEmpty())
         {
             polledEdge = toProcess.poll();
-            for (final Node node : polledEdge.connectedNodes())
+            if (!tollBooth)
             {
-                if (Validators.isOfType(node, BarrierTag.class, BarrierTag.TOLL_BOOTH))
+                for (final Node node : polledEdge.connectedNodes())
                 {
-                    tollBooth = true;
+                    if (Validators.isOfType(node, BarrierTag.class, BarrierTag.TOLL_BOOTH))
+                    {
+                        tollBooth = true;
+                        break;
+                    }
                 }
             }
             for (final Edge edge : polledEdge.connectedEdges())

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheckTest.java
@@ -21,7 +21,7 @@ public class InvalidLanesTagCheckTest
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
     private final Configuration inlineConfiguration = ConfigurationResolver.inlineConfiguration(
-            "{\"InvalidLanesTagCheck\":{\"lanes.filter\":\"lanes->1,1.5,2\"},\"exclude-oneway.minimum\":11}");
+            "{\"InvalidLanesTagCheck\":{\"lanes.filter\":\"lanes->1,1.5,2\"}}");
 
     @Test
     public void validLanesTag()
@@ -37,5 +37,13 @@ public class InvalidLanesTagCheckTest
         this.verifier.actual(this.setup.invalidLanesTag(),
                 new InvalidLanesTagCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void validLanesTagTollBooth()
+    {
+        this.verifier.actual(this.setup.validLanesTagTollBooth(),
+                new InvalidLanesTagCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheckTest.java
@@ -1,0 +1,41 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * Tests for {@link InvalidLanesTagCheck}
+ *
+ * @author bbreithaupt
+ */
+public class InvalidLanesTagCheckTest
+{
+    @Rule
+    public InvalidLanesTagCheckTestRule setup = new InvalidLanesTagCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    private final Configuration inlineConfiguration = ConfigurationResolver.inlineConfiguration(
+            "{\"InvalidLanesTagCheck\":{\"lanes.filter\":\"lanes->1,1.5,2\"},\"exclude-oneway.minimum\":11}");
+
+    @Test
+    public void validLanesTag()
+    {
+        this.verifier.actual(this.setup.validLanesTag(),
+                new InvalidLanesTagCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void invalidLanesTag()
+    {
+        this.verifier.actual(this.setup.invalidLanesTag(),
+                new InvalidLanesTagCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheckTestRule.java
@@ -15,22 +15,19 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
 
 public class InvalidLanesTagCheckTestRule extends CoreTestRule
 {
-    private static final String TEST_1 = "0.0,0.0";
-    private static final String TEST_2 = "0.1,0.1";
-    private static final String TEST_3 = "0.0,0.2";
-    private static final String TEST_4 = "0.1,0.3";
-    private static final String TEST_5 = "0.0,0.4";
-    private static final String TEST_6 = "-0.1,0.5";
-    private static final String TEST_7 = "0.0,0.6";
+    private static final String TEST_1 = "47.2136626201459,-122.443275382856";
+    private static final String TEST_2 = "47.2138327316739,-122.44258668766";
+    private static final String TEST_3 = "47.2136626201459,-122.441897992465";
+    private static final String TEST_4 = "47.2138114677627,-122.440990166979";
+    private static final String TEST_5 = "47.2136200921786,-122.44001973284";
+    private static final String TEST_6 = "47.2135137721113,-122.439127559518";
+    private static final String TEST_7 = "47.2136200921786,-122.438157125378";
 
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = TEST_1)),
-                    @Node(coordinates = @Loc(value = TEST_2)),
                     @Node(coordinates = @Loc(value = TEST_3)),
-                    @Node(coordinates = @Loc(value = TEST_4)),
                     @Node(coordinates = @Loc(value = TEST_5)),
-                    @Node(coordinates = @Loc(value = TEST_6)),
                     @Node(coordinates = @Loc(value = TEST_7)) },
             // edges
             edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
@@ -46,11 +43,8 @@ public class InvalidLanesTagCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = TEST_1)),
-                    @Node(coordinates = @Loc(value = TEST_2)),
                     @Node(coordinates = @Loc(value = TEST_3)),
-                    @Node(coordinates = @Loc(value = TEST_4)),
                     @Node(coordinates = @Loc(value = TEST_5)),
-                    @Node(coordinates = @Loc(value = TEST_6)),
                     @Node(coordinates = @Loc(value = TEST_7)) },
             // edges
             edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
@@ -63,6 +57,25 @@ public class InvalidLanesTagCheckTestRule extends CoreTestRule
                             @Loc(value = TEST_7) }, tags = { "highway=motorway" }) })
     private Atlas invalidLanesTag;
 
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_5), tags = { "barrier=toll_booth" }),
+                    @Node(coordinates = @Loc(value = TEST_7)) },
+            // edges
+            edges = {
+                    @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2),
+                            @Loc(value = TEST_3) }, tags = { "highway=motorway", "lanes=11" }),
+                    @Edge(id = "1001000001", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_4),
+                            @Loc(value = TEST_5) }, tags = { "highway=motorway", "lanes=11" }),
+                    @Edge(id = "1002000001", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_6),
+                            @Loc(value = TEST_7) }, tags = { "highway=motorway" }) })
+    private Atlas validLanesTagTollBooth;
+
     public Atlas validLanesTag()
     {
         return this.validLanesTag;
@@ -71,5 +84,10 @@ public class InvalidLanesTagCheckTestRule extends CoreTestRule
     public Atlas invalidLanesTag()
     {
         return this.invalidLanesTag;
+    }
+
+    public Atlas validLanesTagTollBooth()
+    {
+        return this.validLanesTagTollBooth;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheckTestRule.java
@@ -1,0 +1,75 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * Tests for {@link InvalidLanesTagCheck}
+ *
+ * @author bbreithaupt
+ */
+
+public class InvalidLanesTagCheckTestRule extends CoreTestRule
+{
+    private static final String TEST_1 = "0.0,0.0";
+    private static final String TEST_2 = "0.1,0.1";
+    private static final String TEST_3 = "0.0,0.2";
+    private static final String TEST_4 = "0.1,0.3";
+    private static final String TEST_5 = "0.0,0.4";
+    private static final String TEST_6 = "-0.1,0.5";
+    private static final String TEST_7 = "0.0,0.6";
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_4)),
+                    @Node(coordinates = @Loc(value = TEST_5)),
+                    @Node(coordinates = @Loc(value = TEST_6)),
+                    @Node(coordinates = @Loc(value = TEST_7)) },
+            // edges
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
+                    @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = { "highway=motorway" }),
+                    @Edge(id = "1001000001", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_4),
+                            @Loc(value = TEST_5) }, tags = { "highway=motorway", "lanes=1.5" }),
+                    @Edge(id = "1002000001", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_6),
+                            @Loc(value = TEST_7) }, tags = { "highway=motorway" }) })
+    private Atlas validLanesTag;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_4)),
+                    @Node(coordinates = @Loc(value = TEST_5)),
+                    @Node(coordinates = @Loc(value = TEST_6)),
+                    @Node(coordinates = @Loc(value = TEST_7)) },
+            // edges
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
+                    @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = { "highway=motorway" }),
+                    @Edge(id = "1001000001", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_4),
+                            @Loc(value = TEST_5) }, tags = { "highway=motorway", "lanes=11" }),
+                    @Edge(id = "1002000001", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_6),
+                            @Loc(value = TEST_7) }, tags = { "highway=motorway" }) })
+    private Atlas invalidLanesTag;
+
+    public Atlas validLanesTag()
+    {
+        return this.validLanesTag;
+    }
+
+    public Atlas invalidLanesTag()
+    {
+        return this.invalidLanesTag;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheckTestRule.java
@@ -45,7 +45,7 @@ public class InvalidLanesTagCheckTestRule extends CoreTestRule
             nodes = { @Node(coordinates = @Loc(value = TEST_1)),
                     @Node(coordinates = @Loc(value = TEST_3)),
                     @Node(coordinates = @Loc(value = TEST_5)),
-                    @Node(coordinates = @Loc(value = TEST_7)) },
+                    @Node(coordinates = @Loc(value = TEST_7), tags = { "barrier=toll_booth" }) },
             // edges
             edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
                     @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = { "highway=motorway" }),


### PR DESCRIPTION
This check flags Edges where there is a `lanes` tag with an abnormal value. 

Abnormal values are defined as anything not in the configurable `lanes.filter`.  
The default values are set to `1,1.5,2,3,4,5,6,7,8,9,10`. 

Toll booths are ignored, as they often have an abnormally high number of lanes. 

**OSM Examples:**
1. Way [id:156825478](https://www.openstreetmap.org/way/156825478) is flagged correctly by this check as a highway with no lanes.
2. Way [id:247311654](https://www.openstreetmap.org/way/247311654) is connected to a toll booth and has a high but valid number of lanes. It is not flagged.