### PR TITLE
Street Name Integers Only Check Review

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -224,6 +224,16 @@
       "tags":"highway"
     }
   },
+  "StreetNameIntegersOnlyCheck": {
+    "name_keys.filter":["name","name:left","name:right"],
+    "challenge": {
+      "description": "Tasks containing name tags with only integers",
+      "blurb": "Street Names Integers Only",
+      "instruction": "Correct the road with only integers for names.",
+      "difficulty": "Medium",
+      "tags":"highway,name"
+    }
+  },
   "SnakeRoadCheck": {
     "challenge": {
       "description": "Tasks will include ways that are drawn as a single way, when in reality they should be two or more distinct ways",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -225,7 +225,7 @@
     }
   },
   "StreetNameIntegersOnlyCheck": {
-    "name_keys.filter":["name","name:left","name:right"],
+    "name.keys.filter":["name","name:left","name:right"],
     "challenge": {
       "description": "Tasks containing name tags with only integers",
       "blurb": "Street Names Integers Only",

--- a/docs/checks/streetNameIntegersOnlyCheck.md
+++ b/docs/checks/streetNameIntegersOnlyCheck.md
@@ -16,15 +16,6 @@ The way [id:395169730](https://www.openstreetmap.org/way/395169730) is a road an
 This check takes a configurable list on name tags to search.  
 The defaults are `name`, `name:left`, and `name:right`.
 
-```java
-public StreetNameIntegersOnlyCheck(final Configuration configuration)
-    {
-        super(configuration);
-        this.nameKeys = (List<String>) configurationValue(configuration, "name_keys.filter",
-                NAME_KEYS_DEFAULT);
-    }
-```
-
 In [Atlas](https://github.com/osmlab/atlas), OSM elements are represented as Edges, Points, Lines, 
 Nodes & Relations; in our case, we’re working with [Edges]((https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java)).
 
@@ -47,32 +38,7 @@ The atlas objects are filter to only include Edges that meet the following condi
 ```
 
 The final filtered list has its name tags tested to see if they only contain integers, ignoring spaces.  
-If this is true for any of the name tags, the object is flagged.
-
-```java
-@Override
-    protected Optional<CheckFlag> flag(final AtlasObject object)
-    {
-        // Try to convert name to an integer. If it converts without failure it should be flagged.
-        for (final String nameKey : this.nameKeys)
-        {
-            try
-            {
-                Integer.parseInt(
-                        object.getOsmTags().getOrDefault(nameKey, "a").replaceAll(" ", ""));
-            }
-            catch (final NumberFormatException e)
-            {
-                continue;
-            }
-            this.markAsFlagged(object.getOsmIdentifier());
-            return Optional.of(this.createFlag(object,
-                    this.getLocalizedInstruction(0, object.getOsmIdentifier())));
-        }
-
-        return Optional.empty();
-    }
-```
+If this is true for any of the name tags, the object is flagged. See the `flag` method of this check. 
 
 To learn more about the code, please look at the comments in the source code for the check.
 [StreetNameIntegersOnlyCheck.java](../../src/main/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheck.java)

--- a/docs/checks/streetNameIntegersOnlyCheck.md
+++ b/docs/checks/streetNameIntegersOnlyCheck.md
@@ -1,4 +1,4 @@
-# Invalid Access Tag Check
+# Street Name Integer Only Check
 
 #### Description
 

--- a/docs/checks/streetNameIntegersOnlyCheck.md
+++ b/docs/checks/streetNameIntegersOnlyCheck.md
@@ -39,18 +39,10 @@ The atlas objects are filter to only include Edges that meet the following condi
 @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        if (HighwayTag.isCarNavigableHighway(object) && !this.isFlagged(object.getOsmIdentifier())
-                && object instanceof Edge)
-        {
-            for (final String nameKey : this.nameKeys)
-            {
-                if (object.getOsmTags().containsKey(nameKey))
-                {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return HighwayTag.isCarNavigableHighway(object)
+                && !this.isFlagged(object.getOsmIdentifier()) && object instanceof Edge
+                && this.nameKeys.stream()
+                        .anyMatch(nameKey -> object.getOsmTags().containsKey(nameKey));
     }
 ```
 

--- a/docs/checks/streetNameIntegersOnlyCheck.md
+++ b/docs/checks/streetNameIntegersOnlyCheck.md
@@ -1,0 +1,86 @@
+# Invalid Access Tag Check
+
+#### Description
+
+This check flags roads that have only integers in their name. 
+
+An example of an improper name tag in this case is something like: `name=42`  
+Items like `name=1st Ave` are allowed, and not flagged.
+
+#### Live Example
+
+The way [id:395169730](https://www.openstreetmap.org/way/395169730) is a road and has the name 1543 (an integer).  
+
+#### Code Review
+
+This check takes a configurable list on name tags to search.  
+The defaults are `name`, `name:left`, and `name:right`.
+
+```java
+public StreetNameIntegersOnlyCheck(final Configuration configuration)
+    {
+        super(configuration);
+        this.nameKeys = (List<String>) configurationValue(configuration, "name_keys.filter",
+                NAME_KEYS_DEFAULT);
+    }
+```
+
+In [Atlas](https://github.com/osmlab/atlas), OSM elements are represented as Edges, Points, Lines, 
+Nodes & Relations; in our case, we’re working with [Edges]((https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java)).
+
+The atlas objects are filter to only include Edges that meet the following conditions:
+
+* Has a `highway` tag that denotes it as being car navigable
+* Is not already flagged
+* Has one, or more, of the configurable name tags
+
+
+```java
+@Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        if (HighwayTag.isCarNavigableHighway(object) && !this.isFlagged(object.getOsmIdentifier())
+                && object instanceof Edge)
+        {
+            for (final String nameKey : this.nameKeys)
+            {
+                if (object.getOsmTags().containsKey(nameKey))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+```
+
+The final filtered list has its name tags tested to see if they only contain integers, ignoring spaces.  
+If this is true for any of the name tags, the object is flagged.
+
+```java
+@Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        // Try to convert name to an integer. If it converts without failure it should be flagged.
+        for (final String nameKey : this.nameKeys)
+        {
+            try
+            {
+                Integer.parseInt(
+                        object.getOsmTags().getOrDefault(nameKey, "a").replaceAll(" ", ""));
+            }
+            catch (final NumberFormatException e)
+            {
+                continue;
+            }
+            this.markAsFlagged(object.getOsmIdentifier());
+            return Optional.of(this.createFlag(object,
+                    this.getLocalizedInstruction(0, object.getOsmIdentifier())));
+        }
+
+        return Optional.empty();
+    }
+```
+
+To learn more about the code, please look at the comments in the source code for the check.
+[StreetNameIntegersOnlyCheck.java](../../src/main/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheck.java)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheck.java
@@ -44,7 +44,7 @@ public class StreetNameIntegersOnlyCheck extends BaseCheck
     public StreetNameIntegersOnlyCheck(final Configuration configuration)
     {
         super(configuration);
-        this.nameKeys = (List<String>) configurationValue(configuration, "name_keys.filter",
+        this.nameKeys = (List<String>) configurationValue(configuration, "name.keys.filter",
                 NAME_KEYS_DEFAULT);
     }
 
@@ -77,18 +77,21 @@ public class StreetNameIntegersOnlyCheck extends BaseCheck
         // Try to convert name to an integer. If it converts without failure it should be flagged.
         for (final String nameKey : this.nameKeys)
         {
-            try
+            final Optional<String> nameValue = object.getTag(nameKey);
+            if (nameValue.isPresent())
             {
-                Integer.parseInt(
-                        object.getOsmTags().getOrDefault(nameKey, "a").replaceAll(" ", ""));
+                try
+                {
+                    Integer.parseInt(nameValue.get().replaceAll(" ", ""));
+                }
+                catch (final NumberFormatException e)
+                {
+                    continue;
+                }
+                this.markAsFlagged(object.getOsmIdentifier());
+                return Optional.of(this.createFlag(object,
+                        this.getLocalizedInstruction(0, object.getOsmIdentifier())));
             }
-            catch (final NumberFormatException e)
-            {
-                continue;
-            }
-            this.markAsFlagged(object.getOsmIdentifier());
-            return Optional.of(this.createFlag(object,
-                    this.getLocalizedInstruction(0, object.getOsmIdentifier())));
         }
 
         return Optional.empty();

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheck.java
@@ -58,18 +58,10 @@ public class StreetNameIntegersOnlyCheck extends BaseCheck
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        if (HighwayTag.isCarNavigableHighway(object) && !this.isFlagged(object.getOsmIdentifier())
-                && object instanceof Edge)
-        {
-            for (final String nameKey : this.nameKeys)
-            {
-                if (object.getOsmTags().containsKey(nameKey))
-                {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return HighwayTag.isCarNavigableHighway(object)
+                && !this.isFlagged(object.getOsmIdentifier()) && object instanceof Edge
+                && this.nameKeys.stream()
+                        .anyMatch(nameKey -> object.getOsmTags().containsKey(nameKey));
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheck.java
@@ -1,0 +1,102 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.names.NameLeftTag;
+import org.openstreetmap.atlas.tags.names.NameRightTag;
+import org.openstreetmap.atlas.tags.names.NameTag;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * Auto generated Check template
+ *
+ * @author bbreithaupt
+ */
+public class StreetNameIntegersOnlyCheck extends BaseCheck
+{
+
+    private static final long serialVersionUID = 3439708862406928654L;
+
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
+            .asList("Street {0,number,#} has a name containing only integers.");
+
+    private static final List<String> NAME_KEYS_DEFAULT = Arrays.asList(NameTag.KEY,
+            NameLeftTag.KEY, NameRightTag.KEY);
+
+    private final List<String> nameKeys;
+
+    /**
+     * The default constructor that must be supplied. The Atlas Checks framework will generate the
+     * checks with this constructor, supplying a configuration that can be used to adjust any
+     * parameters that the check uses during operation.
+     *
+     * @param configuration
+     *            the JSON configuration for this check
+     */
+    public StreetNameIntegersOnlyCheck(final Configuration configuration)
+    {
+        super(configuration);
+        this.nameKeys = (List<String>) configurationValue(configuration, "name_keys.filter",
+                NAME_KEYS_DEFAULT);
+    }
+
+    /**
+     * This function will validate if the supplied atlas object is valid for the check.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return {@code true} if this object should be checked
+     */
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        if (HighwayTag.isCarNavigableHighway(object) && !this.isFlagged(object.getOsmIdentifier())
+                && object instanceof Edge)
+        {
+            for (final String nameKey : this.nameKeys)
+            {
+                if (object.getOsmTags().containsKey(nameKey))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * This is the actual function that will check to see whether the object needs to be flagged.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return an optional {@link CheckFlag} object that
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        // Try to convert name to an integer. If it converts without failure it should be flagged.
+        for (final String nameKey : this.nameKeys)
+        {
+            try
+            {
+                Integer.parseInt(object.getOsmTags().getOrDefault(nameKey, "a"));
+            }
+            catch (final NumberFormatException e)
+            {
+                break;
+            }
+            this.markAsFlagged(object.getOsmIdentifier());
+            return Optional.of(this.createFlag(object,
+                    this.getLocalizedInstruction(0, object.getOsmIdentifier())));
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheck.java
@@ -15,7 +15,8 @@ import org.openstreetmap.atlas.tags.names.NameTag;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
- * Auto generated Check template
+ * This check flags {@link Edge}s that are car navigable highways and have a name tag that contains
+ * only integers.
  *
  * @author bbreithaupt
  */
@@ -86,11 +87,12 @@ public class StreetNameIntegersOnlyCheck extends BaseCheck
         {
             try
             {
-                Integer.parseInt(object.getOsmTags().getOrDefault(nameKey, "a"));
+                Integer.parseInt(
+                        object.getOsmTags().getOrDefault(nameKey, "a").replaceAll(" ", ""));
             }
             catch (final NumberFormatException e)
             {
-                break;
+                continue;
             }
             this.markAsFlagged(object.getOsmIdentifier());
             return Optional.of(this.createFlag(object,
@@ -98,5 +100,11 @@ public class StreetNameIntegersOnlyCheck extends BaseCheck
         }
 
         return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheckTest.java
@@ -1,0 +1,6 @@
+import static org.junit.Assert.*;
+
+public class StreetNameIntegersOnlyCheckTest
+{
+
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheckTest.java
@@ -1,6 +1,54 @@
-import static org.junit.Assert.*;
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * Tests for {@link StreetNameIntegersOnlyCheck}
+ *
+ * @author bbreithaupt
+ */
 
 public class StreetNameIntegersOnlyCheckTest
 {
+    @Rule
+    public StreetNameIntegersOnlyCheckTestRule setup = new StreetNameIntegersOnlyCheckTestRule();
 
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void motorwayWithIntegerNameTag()
+    {
+        this.verifier.actual(this.setup.motorwayWithIntegerNameTag(),
+                new StreetNameIntegersOnlyCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void motorwayWithNonIntegerNameTag()
+    {
+        this.verifier.actual(this.setup.motorwayWithNonIntegerNameTag(),
+                new StreetNameIntegersOnlyCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void motorwayWithMixedNameTag()
+    {
+        this.verifier.actual(this.setup.motorwayWithMixedNameTag(),
+                new StreetNameIntegersOnlyCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void motorwayWithMixedNameTagIntegerNameLeftTag()
+    {
+        this.verifier.actual(this.setup.motorwayWithMixedNameTagIntegerNameLeftTag(),
+                new StreetNameIntegersOnlyCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheckTest.java
@@ -21,33 +21,33 @@ public class StreetNameIntegersOnlyCheckTest
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
     @Test
-    public void motorwayWithIntegerNameTag()
+    public void motorwayWithIntegerNameTagTest()
     {
-        this.verifier.actual(this.setup.motorwayWithIntegerNameTag(),
+        this.verifier.actual(this.setup.motorwayWithIntegerNameTagAtlas(),
                 new StreetNameIntegersOnlyCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void motorwayWithNonIntegerNameTag()
+    public void motorwayWithNonIntegerNameTagTest()
     {
-        this.verifier.actual(this.setup.motorwayWithNonIntegerNameTag(),
+        this.verifier.actual(this.setup.motorwayWithNonIntegerNameTagAtlas(),
                 new StreetNameIntegersOnlyCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void motorwayWithMixedNameTag()
+    public void motorwayWithMixedNameTagTest()
     {
-        this.verifier.actual(this.setup.motorwayWithMixedNameTag(),
+        this.verifier.actual(this.setup.motorwayWithMixedNameTagAtlas(),
                 new StreetNameIntegersOnlyCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void motorwayWithMixedNameTagIntegerNameLeftTag()
+    public void motorwayWithMixedNameTagIntegerNameLeftTagTest()
     {
-        this.verifier.actual(this.setup.motorwayWithMixedNameTagIntegerNameLeftTag(),
+        this.verifier.actual(this.setup.motorwayWithMixedNameTagIntegerNameLeftTagAtlas(),
                 new StreetNameIntegersOnlyCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheckTestRule.java
@@ -25,7 +25,7 @@ public class StreetNameIntegersOnlyCheckTestRule extends CoreTestRule
             // edges
             edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
                     @Loc(value = TEST_2) }, tags = { "highway=motorway", "name=20 19" }) })
-    private Atlas motorwayWithIntegerNameTag;
+    private Atlas motorwayWithIntegerNameTagAtlas;
 
     @TestAtlas(
             // nodes
@@ -34,7 +34,7 @@ public class StreetNameIntegersOnlyCheckTestRule extends CoreTestRule
             // edges
             edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
                     @Loc(value = TEST_2) }, tags = { "highway=motorway", "name=Way St" }) })
-    private Atlas motorwayWithNonIntegerNameTag;
+    private Atlas motorwayWithNonIntegerNameTagAtlas;
 
     @TestAtlas(
             // nodes
@@ -43,7 +43,7 @@ public class StreetNameIntegersOnlyCheckTestRule extends CoreTestRule
             // edges
             edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
                     @Loc(value = TEST_2) }, tags = { "highway=motorway", "name=1st St" }) })
-    private Atlas motorwayWithMixedNameTag;
+    private Atlas motorwayWithMixedNameTagAtlas;
 
     @TestAtlas(
             // nodes
@@ -53,25 +53,25 @@ public class StreetNameIntegersOnlyCheckTestRule extends CoreTestRule
             edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
                     @Loc(value = TEST_2) }, tags = { "highway=motorway", "name=1st St",
                             "name:left=1" }) })
-    private Atlas motorwayWithMixedNameTagIntegerNameLeftTag;
+    private Atlas motorwayWithMixedNameTagIntegerNameLeftTagAtlas;
 
-    public Atlas motorwayWithIntegerNameTag()
+    public Atlas motorwayWithIntegerNameTagAtlas()
     {
-        return this.motorwayWithIntegerNameTag;
+        return this.motorwayWithIntegerNameTagAtlas;
     }
 
-    public Atlas motorwayWithNonIntegerNameTag()
+    public Atlas motorwayWithNonIntegerNameTagAtlas()
     {
-        return this.motorwayWithNonIntegerNameTag;
+        return this.motorwayWithNonIntegerNameTagAtlas;
     }
 
-    public Atlas motorwayWithMixedNameTag()
+    public Atlas motorwayWithMixedNameTagAtlas()
     {
-        return this.motorwayWithMixedNameTag;
+        return this.motorwayWithMixedNameTagAtlas;
     }
 
-    public Atlas motorwayWithMixedNameTagIntegerNameLeftTag()
+    public Atlas motorwayWithMixedNameTagIntegerNameLeftTagAtlas()
     {
-        return this.motorwayWithMixedNameTagIntegerNameLeftTag;
+        return this.motorwayWithMixedNameTagIntegerNameLeftTagAtlas;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheckTestRule.java
@@ -1,11 +1,11 @@
 package org.openstreetmap.atlas.checks.validation.tag;
 
-
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
-import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
 
 /**
  * Tests for {@link StreetNameIntegersOnlyCheck}
@@ -13,11 +13,65 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
  * @author bbreithaupt
  */
 
-public class StreetNameIntegersOnlyCheckTest
+public class StreetNameIntegersOnlyCheckTestRule extends CoreTestRule
 {
-    @Rule
-    public StreetNameIntegersOnlyCheckTestRule setup = new StreetNameIntegersOnlyCheckTestRule();
+    private static final String TEST_1 = "47.2136626201459,-122.443275382856";
+    private static final String TEST_2 = "47.2138327316739,-122.44258668766";
 
-    @Rule
-    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)) },
+            // edges
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
+                    @Loc(value = TEST_2) }, tags = { "highway=motorway", "name=20 19" }) })
+    private Atlas motorwayWithIntegerNameTag;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)) },
+            // edges
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
+                    @Loc(value = TEST_2) }, tags = { "highway=motorway", "name=Way St" }) })
+    private Atlas motorwayWithNonIntegerNameTag;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)) },
+            // edges
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
+                    @Loc(value = TEST_2) }, tags = { "highway=motorway", "name=1st St" }) })
+    private Atlas motorwayWithMixedNameTag;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)) },
+            // edges
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
+                    @Loc(value = TEST_2) }, tags = { "highway=motorway", "name=1st St",
+                            "name:left=1" }) })
+    private Atlas motorwayWithMixedNameTagIntegerNameLeftTag;
+
+    public Atlas motorwayWithIntegerNameTag()
+    {
+        return this.motorwayWithIntegerNameTag;
+    }
+
+    public Atlas motorwayWithNonIntegerNameTag()
+    {
+        return this.motorwayWithNonIntegerNameTag;
+    }
+
+    public Atlas motorwayWithMixedNameTag()
+    {
+        return this.motorwayWithMixedNameTag;
+    }
+
+    public Atlas motorwayWithMixedNameTagIntegerNameLeftTag()
+    {
+        return this.motorwayWithMixedNameTagIntegerNameLeftTag;
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/StreetNameIntegersOnlyCheckTestRule.java
@@ -1,0 +1,23 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * Tests for {@link StreetNameIntegersOnlyCheck}
+ *
+ * @author bbreithaupt
+ */
+
+public class StreetNameIntegersOnlyCheckTest
+{
+    @Rule
+    public StreetNameIntegersOnlyCheckTestRule setup = new StreetNameIntegersOnlyCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+}


### PR DESCRIPTION
This check flags edges that have only integers in their name. 

An example of an improper name tag in this case is something like: `name=42`  
Items like `name=1st Ave` are allowed, and not flagged.

Multiple variations of the name tag can be checked by adding their tag key to the configurable `name_keys.filter`. Default values are:
* name
* name:left
* name:right

**OSM Example:**
1. The way [id:395169730](https://www.openstreetmap.org/way/395169730) is a road and has the name 1543 (an integer).