### PR TITLE
Mixed Case Name Check Review

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -141,7 +141,7 @@
     "lower_case":{
       "articles":["and", "to", "of"],
       "prepositions":["and", "from", "to", "of", "by", "upon", "on", "off", "at", "as", "into",
-        "like", "near", "onto", "per", "till", "up", "via", "with", "for"]
+        "like", "near", "onto", "per", "till", "up", "via", "with", "for", "in"]
     },
     "words.split.characters":" -/()&@–",
     "name_affixes":["Mc", "Mac", "Mck","Mhic", "Mic"],

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -138,8 +138,11 @@
       "SGP", "SLB", "ZAF", "SWZ", "TZA", "TON", "TTO", "TCA", "UGA", "GBR", "USA", "VUT",
       "ZMB", "ZWE"],
     "name.language.keys":["name:en"],
-    "lower_case_words":["and", "to", "of", "the"],
-    "characters.capital.prefix":"-/(&",
+    "lower_case":{
+      "prepositions":["and", "to", "of"],
+      "articles":["and", "from", "to", "of", "by", "upon", "on", "off", "at", "as", "into", "like", "near", "onto", "per", "till", "up", "via", "with"]
+    },
+    "words.split.characters":" -/(&@–",
     "name_affixes":["Mc", "Mac", "Mck","Mhic", "Mic"],
     "challenge": {
       "description": "Tasks containing objects with mixed case names.",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -145,6 +145,7 @@
     },
     "words.split.characters":" -/&@–",
     "name_affixes":["Mc", "Mac", "Mck","Mhic", "Mic"],
+    "units.mixed_case":["kV"],
     "challenge": {
       "description": "Tasks containing objects with mixed case names.",
       "blurb": "Mixed Case Name",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -139,9 +139,10 @@
       "ZMB", "ZWE"],
     "name.language.keys":["name:en"],
     "lower_case":{
-      "articles":["and", "to", "of"],
-      "prepositions":["and", "from", "to", "of", "by", "upon", "on", "off", "at", "as", "into",
-        "like", "near", "onto", "per", "till", "up", "via", "with", "for", "in"]
+      "articles":["a", "an", "the"],
+      "prepositions":["and", "from",
+        "to", "of", "by", "upon", "on", "off", "at", "as", "into", "like", "near", "onto",
+        "per", "till", "up", "via", "with", "for", "in"]
     },
     "words.split.characters":" -/&@–",
     "name_affixes":["Mc", "Mac", "Mck","Mhic", "Mic"],

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -132,7 +132,7 @@
     }
   },
   "MixedCaseNameCheck": {
-    "check_name.countries":["AIA", "ATG", "AUT", "BHS", "BRB", "BLZ", "BMU", "BWA", "VGB",
+    "check_name.countries":["AIA", "ATG", "AUS", "BHS", "BRB", "BLZ", "BMU", "BWA", "VGB",
       "CMR", "CAN", "CYM", "DMA", "FJI", "GMB", "GHA", "GIB", "GRD", "GUY", "IRL", "JAM",
       "KEN", "LSO", "MWI", "MLT", "MUS", "MSR", "NAM", "NZL", "NGA", "PNG", "SYC", "SLE",
       "SGP", "SLB", "ZAF", "SWZ", "TZA", "TON", "TTO", "TCA", "UGA", "GBR", "USA", "VUT",
@@ -141,7 +141,7 @@
     "lower_case":{
       "prepositions":["and", "to", "of"],
       "articles":["and", "from", "to", "of", "by", "upon", "on", "off", "at", "as", "into",
-        "like", "near", "onto", "per", "till", "up", "via", "with"]
+        "like", "near", "onto", "per", "till", "up", "via", "with", "for"]
     },
     "words.split.characters":" -/()&@–",
     "name_affixes":["Mc", "Mac", "Mck","Mhic", "Mic"],

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -138,7 +138,7 @@
       "SGP", "SLB", "ZAF", "SWZ", "TZA", "TON", "TTO", "TCA", "UGA", "GBR", "USA", "VUT",
       "ZMB", "ZWE"],
     "name.language.keys":["name:en"],
-    "lower_case_words":["and", "to", "of", "de", "del", "los", "la", "y"],
+    "lower_case_words":["and", "to", "of", "the"],
     "characters.capital.prefix":"-/(&",
     "name_affixes":["Mc", "Mac", "Mck","Mhic", "Mic"],
     "challenge": {

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -137,15 +137,15 @@
       "KEN", "LSO", "MWI", "MLT", "MUS", "MSR", "NAM", "NZL", "NGA", "PNG", "SYC", "SLE",
       "SGP", "SLB", "ZAF", "SWZ", "TZA", "TON", "TTO", "TCA", "UGA", "GBR", "USA", "VUT",
       "ZMB", "ZWE"],
-    "name.language.keys":["name:en"],
-    "lower_case":{
-      "articles":["a", "an", "the"],
-      "prepositions":["and", "from", "to", "of", "by", "upon", "on", "off", "at", "as", "into",
-        "like", "near", "onto", "per", "till", "up", "via", "with", "for", "in"]
+    "name":{
+      "language.keys":["name:en"],
+      "affixes":["Mc", "Mac", "Mck","Mhic", "Mic"],
+      "articles": ["a", "an", "the"],
+      "prepositions": ["and", "from", "to", "of", "by", "upon", "on", "off", "at", "as",
+        "into", "like", "near", "onto", "per", "till", "up", "via", "with", "for", "in"],
+      "units":["kv"]
     },
-    "words.split.characters":" -/&@–",
-    "name_affixes":["Mc", "Mac", "Mck","Mhic", "Mic"],
-    "units.mixed_case":["kV"],
+    "regex.split":" -/&@–",
     "challenge": {
       "description": "Tasks containing objects with mixed case names.",
       "blurb": "Mixed Case Name",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -139,8 +139,8 @@
       "ZMB", "ZWE"],
     "name.language.keys":["name:en"],
     "lower_case":{
-      "prepositions":["and", "to", "of"],
-      "articles":["and", "from", "to", "of", "by", "upon", "on", "off", "at", "as", "into",
+      "articles":["and", "to", "of"],
+      "prepositions":["and", "from", "to", "of", "by", "upon", "on", "off", "at", "as", "into",
         "like", "near", "onto", "per", "till", "up", "via", "with", "for"]
     },
     "words.split.characters":" -/()&@–",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -140,9 +140,10 @@
     "name.language.keys":["name:en"],
     "lower_case":{
       "prepositions":["and", "to", "of"],
-      "articles":["and", "from", "to", "of", "by", "upon", "on", "off", "at", "as", "into", "like", "near", "onto", "per", "till", "up", "via", "with"]
+      "articles":["and", "from", "to", "of", "by", "upon", "on", "off", "at", "as", "into",
+        "like", "near", "onto", "per", "till", "up", "via", "with"]
     },
-    "words.split.characters":" -/(&@–",
+    "words.split.characters":" -/()&@–",
     "name_affixes":["Mc", "Mac", "Mck","Mhic", "Mic"],
     "challenge": {
       "description": "Tasks containing objects with mixed case names.",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -131,6 +131,18 @@
       "difficulty": "MEDIUM"
     }
   },
+  "MixedCaseNameCheck": {
+    "name.language.keys":["name:en"],
+    "lower_case_words":["and", "to", "of"],
+    "characters.capital.prefix":"-/(&",
+    "name_affixes":["Mc", "Mac", "Mck","Mhic", "Mic"],
+    "challenge": {
+      "description": "Tasks containing objects with mixed case names.",
+      "blurb": "Mixed Case Name",
+      "instruction": "Correct the listed names tags so they conform to capitalization standards",
+      "difficulty": "MEDIUM"
+    }
+  },
   "OneMemberRelationCheck": {
     "challenge": {
       "description": "Tasks containing relations with only one member.",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -143,7 +143,7 @@
       "prepositions":["and", "from", "to", "of", "by", "upon", "on", "off", "at", "as", "into",
         "like", "near", "onto", "per", "till", "up", "via", "with", "for", "in"]
     },
-    "words.split.characters":" -/()&@–",
+    "words.split.characters":" -/&@–",
     "name_affixes":["Mc", "Mac", "Mck","Mhic", "Mic"],
     "challenge": {
       "description": "Tasks containing objects with mixed case names.",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -140,9 +140,8 @@
     "name.language.keys":["name:en"],
     "lower_case":{
       "articles":["a", "an", "the"],
-      "prepositions":["and", "from",
-        "to", "of", "by", "upon", "on", "off", "at", "as", "into", "like", "near", "onto",
-        "per", "till", "up", "via", "with", "for", "in"]
+      "prepositions":["and", "from", "to", "of", "by", "upon", "on", "off", "at", "as", "into",
+        "like", "near", "onto", "per", "till", "up", "via", "with", "for", "in"]
     },
     "words.split.characters":" -/&@–",
     "name_affixes":["Mc", "Mac", "Mck","Mhic", "Mic"],

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -132,8 +132,13 @@
     }
   },
   "MixedCaseNameCheck": {
+    "check_name.countries":["AIA", "ATG", "AUT", "BHS", "BRB", "BLZ", "BMU", "BWA", "VGB",
+      "CMR", "CAN", "CYM", "DMA", "FJI", "GMB", "GHA", "GIB", "GRD", "GUY", "IRL", "JAM",
+      "KEN", "LSO", "MWI", "MLT", "MUS", "MSR", "NAM", "NZL", "NGA", "PNG", "SYC", "SLE",
+      "SGP", "SLB", "ZAF", "SWZ", "TZA", "TON", "TTO", "TCA", "UGA", "GBR", "USA", "VUT",
+      "ZMB", "ZWE"],
     "name.language.keys":["name:en"],
-    "lower_case_words":["and", "to", "of"],
+    "lower_case_words":["and", "to", "of", "de", "del", "los", "la", "y"],
     "characters.capital.prefix":"-/(&",
     "name_affixes":["Mc", "Mac", "Mck","Mhic", "Mic"],
     "challenge": {

--- a/docs/checks/mixedCaseNameCheck.md
+++ b/docs/checks/mixedCaseNameCheck.md
@@ -108,6 +108,7 @@ The second is a list of `name:[ISOcode]` tags to check. Default values are:
 
 A final configurable is a list of characters that names are split by to for words. Its default values are: 
 
+* SPACE
 * \-
 * /
 * (
@@ -118,7 +119,7 @@ A final configurable is a list of characters that names are split by to for word
 
 #### Live Examples
 
-1. Way [id:4780932622](https://www.openstreetmap.org/node/4780932622) has the name `NZ Convenience store`. It is flagged because the S in store should be capitalised. 
+1. Way [id:4780932622](https://www.openstreetmap.org/node/4780932622) has the name `NZ Convenience store`. It is flagged because the S in store should be capitalized. 
 
 #### Code Review
 

--- a/docs/checks/mixedCaseNameCheck.md
+++ b/docs/checks/mixedCaseNameCheck.md
@@ -8,7 +8,7 @@ The standards are as follows:
 
 * Words must start with a capital unless:
     * The first letter is preceded by a number
-    * All the words are lower case
+    * All the words in the name are lower case
 * All other letters must be lower case unless: 
     * They follow an apostrophe and, they are not the last letter of the word
     * The entire word is uppercase, except the last letter if it follows or is followed by an apostrophe

--- a/docs/checks/mixedCaseNameCheck.md
+++ b/docs/checks/mixedCaseNameCheck.md
@@ -1,0 +1,212 @@
+# Mixed Case Name Check
+
+This check flags objects with name tags that improperly use mixed cases.
+
+Proper case use is defined by set standards and configurable exceptions. 
+
+The standards are as follows:
+
+* Words must start with a capital unless:
+    * There are no other words in the name
+* All other letters must be lower case unless: 
+    * They follow an apostrophe and are not the last letter of the word
+    * The entire word is uppercase
+
+The standards are broken by the following configurable exceptions (with default values):
+
+* Words that do not need to start with a capital:
+    * and
+    * to
+    * of
+    * the
+* Symbols that may be followed by a capital:
+    * \-
+    * /
+    * (
+    * &
+* Name affixes that may be followed by a capital:
+    * Mc
+    * Mac
+    * Mck
+    * Mhic
+    * Mic
+    
+These configurables allow this check to be adapted to test different languages.  
+OSM uses the `name` tag for the name in a locations primary language, and `name:[ISOcode]` for other languages.
+This check uses two configurable to control what languages are checked.
+
+The first is a list of ISO codes for countries that should have there `name` tag checked. It has default values of:
+
+* AIA
+* ATG
+* AUT
+* BHS
+* BRB
+* BLZ
+* BMU
+* BWA
+* VGB
+* CMR
+* CAN
+* CYM
+* DMA
+* FJI
+* GMB
+* GHA
+* GIB
+* GRD
+* GUY
+* IRL
+* JAM
+* KEN
+* LSO
+* MWI
+* MLT
+* MUS
+* MSR
+* NAM
+* NZL
+* NGA
+* PNG
+* SYC
+* SLE
+* SGP
+* SLB
+* ZAF
+* SWZ
+* TZA
+* TON
+* TTO
+* TCA
+* UGA
+* GBR
+* USA
+* VUT
+* ZMB
+* ZWE
+
+The second is a list of `name:[ISOcode]` tags to check. Default values are:
+
+* name:en
+
+#### Live Examples
+
+1. Way [id:4780932622](https://www.openstreetmap.org/node/4780932622) has the name `NZ Convenience store`. It is flagged because the S in store should be capitalised. 
+
+#### Code Review
+
+In [Atlas](https://github.com/osmlab/atlas), OSM elements are represented as Edges, Points, Lines, Nodes, Areas & Relations; in our case, we’re are looking at
+[Edges](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java),
+[Lines](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Line.java),
+[Nodes](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Node.java),
+[Points](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Point.java), and
+[Areas](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Area.java).
+
+Our first goal is to validate the incoming Atlas object. Valid features for this check will satisfy the following conditions:
+
+* It is an Edge, Line, Node, Point, or Area
+* It is a country where the `name` tag should be checked and it has a `name` tag or it has a one of the `name:[ISOcode]` tags.
+* It has not already been flagged
+
+```java
+@Override
+public boolean validCheckForObject(final AtlasObject object)
+{
+    return !(object instanceof Relation) && !this.isFlagged(object.getOsmIdentifier())
+            && ((object.getTags().containsKey(ISOCountryTag.KEY)
+                    && checkNameCountries.contains(object.tag(ISOCountryTag.KEY).toUpperCase())
+                    && Validators.hasValuesFor(object, NameTag.class))
+                    || languageNameTags.stream()
+                            .anyMatch(key -> object.getOsmTags().containsKey(key)));
+}
+```
+
+Next the objects have each of their name tags, that are being checked, tested for proper use of case.  
+Each improper tag is noted in the output.
+
+```java
+@Override
+protected Optional<CheckFlag> flag(final AtlasObject object)
+{
+    final List<String> mixedCaseNameTags = new ArrayList<>();
+    final Map<String, String> osmTags = object.getOsmTags();
+
+    // Check ISO against list of countries for testing name tag
+    if (checkNameCountries.contains(object.tag(ISOCountryTag.KEY).toUpperCase())
+            && Validators.hasValuesFor(object, NameTag.class)
+            && isMixedCase(osmTags.get(NameTag.KEY)))
+    {
+        mixedCaseNameTags.add("name");
+    }
+    // Check all language name tags
+    for (final String key : languageNameTags)
+    {
+        if (osmTags.containsKey(key) && isMixedCase(osmTags.get(key)))
+        {
+            mixedCaseNameTags.add(key);
+        }
+
+    }
+
+    // If mix case id detected, flag
+    if (!mixedCaseNameTags.isEmpty())
+    {
+        this.markAsFlagged(object.getOsmIdentifier());
+        final String osmType;
+        // Get OSM type for object
+        if (object instanceof LocationItem)
+        {
+            osmType = "Node";
+        }
+        else
+        {
+            osmType = "Way";
+        }
+        // Instruction includes type of OSM object and list of flagged tags
+        return Optional.of(this.createFlag(object, this.getLocalizedInstruction(0, osmType,
+                object.getOsmIdentifier(), String.join(", ", mixedCaseNameTags))));
+    }
+    return Optional.empty();
+}
+```
+
+The testing of the name values is performed by the following. It splits each name into words based on spaces and tests each. 
+It returns true when improper use of case is found.
+
+```java
+private boolean isMixedCase(final String value)
+{
+    // Split into words based on spaces
+    final String[] wordArray = value.split(" ");
+    // Check each word
+    for (final String word : wordArray)
+    {
+        // If there is more than 1 word and the word is not in the lower case list: check that
+        // the first letter is a capital
+        if (wordArray.length > 1 && !lowerCaseWords.contains(word))
+        {
+            final Matcher firstLetterMatcher = Pattern.compile("\\p{L}").matcher(word);
+            if (firstLetterMatcher.find()
+                    && Character.isLowerCase(firstLetterMatcher.group().charAt(0)))
+            {
+                return true;
+            }
+        }
+        // If the word is not all upper case: check if all the letters not following config
+        // specified characters and strings, and apostrophes, are lower case
+        if (Pattern.compile("[\\p{L}&&[^\\p{Lu}]]").matcher(word).find()
+                && Pattern
+                        .compile(String.format(
+                                "(\\p{L}.*(?<![\\Q%1$s\\E']|%2$s)(\\p{Lu}))|(\\p{L}.*(?<=')\\p{Lu}(?!.))",
+                                this.specialCharacters, this.nameAffixes))
+                        .matcher(word).find())
+        {
+            return true;
+        }
+    }
+    return false;
+}
+```
+
+To learn more about the code, please look at the comments in the source code for the check.  
+[MixedCaseNameCheck](../../src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java)

--- a/docs/checks/mixedCaseNameCheck.md
+++ b/docs/checks/mixedCaseNameCheck.md
@@ -7,7 +7,6 @@ Proper case use is defined by set standards and configurable exceptions.
 The standards are as follows:
 
 * Words must start with a capital unless:
-    * There are no other words in the name
     * The first letter is preceded by a number
 * All other letters must be lower case unless: 
     * They follow an apostrophe and, they are not the last letter of the word
@@ -111,8 +110,6 @@ A final configurable is a list of characters that names are split by to for word
 * SPACE
 * \-
 * /
-* (
-* )
 * &
 * @
 * –
@@ -196,41 +193,51 @@ protected Optional<CheckFlag> flag(final AtlasObject object)
 }
 ```
 
-The testing of the name values is performed by the following. It splits each name into words based on the configurable character list, and tests each. 
+The testing of the name values is performed by the following. It first tests to see if all the letters are lower case. If there are upper case letters, it splits each name into words based on the configurable character list, and tests each. 
 It returns true when improper use of case is found.
 
 ```java
 private boolean isMixedCase(final String value)
 {
-    // Split into words based on configurable characters
-    final String[] wordArray = value.split("[\\Q" + this.splitCharacters + "\\E]");
-    boolean firstWord = true;
-    // Check each word
-    for (final String word : wordArray)
+    // Check if it is all lower case
+    if (Pattern.compile("\\p{Lu}").matcher(value).find())
     {
-        // If there is more than 1 word, the word is not in the list of prepositions, and the word is not both in the article list and not the first word: check that
-        // the first letter is a capital
-        if (wordArray.length > 1 && !lowerCasePrepositions.contains(word)
-                && !(!firstWord && lowerCaseArticles.contains(word)))
+        // Split into words based on configurable characters
+        final String[] wordArray = value.split("[\\Q" + this.splitCharacters + "\\E]");
+        boolean firstWord = true;
+        // Check each word
+        for (final String word : wordArray)
         {
-            final Matcher firstLetterMatcher = Pattern.compile("\\p{L}").matcher(word);
-            if (firstLetterMatcher.find()
-                    && Character.isLowerCase(firstLetterMatcher.group().charAt(0))
-                    && !(firstLetterMatcher.start() != 0
-                            && Character.isDigit(word.charAt(firstLetterMatcher.start() - 1))))
+            // If the word is not in the list of prepositions, and the
+            // word is not both in the article list and not the first word: check that
+            // the first letter is a capital
+            if (!lowerCasePrepositions.contains(word)
+                    && !(!firstWord && lowerCaseArticles.contains(word)))
+            {
+                final Matcher firstLetterMatcher = Pattern.compile("\\p{L}").matcher(word);
+                // If the first letter is lower case: return true if it is not preceded by a
+                // number
+                if (firstLetterMatcher.find()
+                        && Character.isLowerCase(firstLetterMatcher.group().charAt(0))
+                        && !(firstLetterMatcher.start() != 0 && Character
+                                .isDigit(word.charAt(firstLetterMatcher.start() - 1))))
+                {
+                    return true;
+                }
+            }
+            // If the word is not all upper case: check if all the letters not following
+            // apostrophes, unless at the end of the word, are lower case
+            if (Pattern.compile("\\p{Ll}").matcher(word).find()
+                    && !Pattern.compile("([^\\p{Ll}]+'\\p{Ll})|([^\\p{Ll}]+\\p{Ll}')")
+                            .matcher(word).matches()
+                    && Pattern.compile(String.format(
+                            "(\\p{L}.*(?<!'|%1$s)(\\p{Lu}))|(\\p{L}.*(?<=')\\p{Lu}(?!.))",
+                            this.nameAffixes)).matcher(word).find())
             {
                 return true;
             }
+            firstWord = false;
         }
-        // If the word is not all upper case: check if all the letters not following apostrophes, unless at the end of the word, are lower case
-        if (Pattern.compile("[\\p{L}&&[^\\p{Lu}]]").matcher(word).find() && Pattern.compile(
-                String.format("(\\p{L}.*(?<!'|%1$s)(\\p{Lu}))|(\\p{L}.*(?<=')\\p{Lu}(?!.))",
-                        this.nameAffixes))
-                .matcher(word).find())
-        {
-            return true;
-        }
-        firstWord = false;
     }
     return false;
 }

--- a/docs/checks/mixedCaseNameCheck.md
+++ b/docs/checks/mixedCaseNameCheck.md
@@ -112,12 +112,13 @@ Next, each word is checked against configurable lists of articles, prepositions,
 
 ```java
 // Check if the word is intentionally mixed case
-if (!Pattern.compile("[^\\p{L}]*\\p{Digit}[\\Q"+this.mixedCaseUnits+"\\E][^\\p{L}]*").matcher(word).find())
+if (!isMixedCaseUnit(word))
 {
     // If the word is not in the list of prepositions, and the
     // word is not both in the article list and not the first word: check that
     // the first letter is a capital
-    if (!lowerCasePrepositions.contains(word) && !(!firstWord && lowerCaseArticles.contains(word)))
+    if (!this.lowerCasePrepositions.contains(word)
+            && !(!firstWord && this.lowerCaseArticles.contains(word)))
     {
 ```
 
@@ -141,9 +142,8 @@ Finally, the rest of the letters are check to see if they are lower case unless 
 ```java
 // If the word is not all upper case: check if all the letters not following
 // apostrophes, unless at the end of the word, are lower case
-if (Pattern.compile("\\p{Ll}").matcher(word).find() && !Pattern.compile("([^\\p{Ll}]+'\\p{Ll})|([^\\p{Ll}]+\\p{Ll}')").matcher(word)
-        .matches() && Pattern.compile(String.format(
-        "(\\p{L}.*(?<!'|%1$s)(\\p{Lu}))|(\\p{L}.*(?<=')\\p{Lu}(?!.))", this.nameAffixes)).matcher(word).find())
+if (Pattern.compile("\\p{Ll}").matcher(word).find()
+        && !isMixedCaseApostrophe(word) && isProperNonFirstCapital(word))
 {
     return true;
 }

--- a/docs/checks/mixedCaseNameCheck.md
+++ b/docs/checks/mixedCaseNameCheck.md
@@ -40,6 +40,7 @@ The standards are broken by the following configurable exceptions (with default 
     * up
     * via
     * with
+    * for
 * Name affixes that may be followed by a capital:
     * Mc
     * Mac
@@ -55,7 +56,7 @@ The first is a list of ISO codes for countries that should have there `name` tag
 
 * AIA
 * ATG
-* AUT
+* AUS
 * BHS
 * BRB
 * BLZ

--- a/docs/checks/mixedCaseNameCheck.md
+++ b/docs/checks/mixedCaseNameCheck.md
@@ -10,17 +10,16 @@ The standards are as follows:
     * There are no other words in the name
     * The first letter is preceded by a number
 * All other letters must be lower case unless: 
-    * They follow an apostrophe and are not the last letter of the word
-    * The entire word is uppercase
+    * They follow an apostrophe and, they are not the last letter of the word
+    * The entire word is uppercase, except the last letter if it follows or is followed by an apostrophe
 
 The standards are broken by the following configurable exceptions (with default values):
 
-* Prepositions that do not need to start with a capital:
-    * and
-    * to
-    * of
+* Articles that are capitalised only if they are the first word:
+    * a
+    * an
     * the
-* Articles that are capitalised only if they are the first word
+* Prepositions that do not need to start with a capital:
     * and
     * from
     * to
@@ -41,6 +40,7 @@ The standards are broken by the following configurable exceptions (with default 
     * via
     * with
     * for
+    * in
 * Name affixes that may be followed by a capital:
     * Mc
     * Mac

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -198,10 +198,12 @@ public class MixedCaseNameCheck extends BaseCheck
             }
             // If the word is not all upper case: check if all the letters not following
             // apostrophes, unless at the end of the word, are lower case
-            if (Pattern.compile("[\\p{L}&&[^\\p{Lu}]]").matcher(word).find() && Pattern.compile(
-                    String.format("(\\p{L}.*(?<!'|%1$s)(\\p{Lu}))|(\\p{L}.*(?<=')\\p{Lu}(?!.))",
-                            this.nameAffixes))
-                    .matcher(word).find())
+            if (Pattern.compile("\\p{Ll}").matcher(word).find()
+                    && !Pattern.compile("([^\\p{Ll}]+'\\p{Ll})|([^\\p{Ll}]+\\p{Ll}')").matcher(word)
+                            .matches()
+                    && Pattern.compile(String.format(
+                            "(\\p{L}.*(?<!'|%1$s)(\\p{Lu}))|(\\p{L}.*(?<=')\\p{Lu}(?!.))",
+                            this.nameAffixes)).matcher(word).find())
             {
                 return true;
             }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -1,0 +1,146 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.openstreetmap.atlas.tags.ISOCountryTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.tags.names.NameTag;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * Auto generated Check template
+ *
+ * @author bbreithaupt
+ */
+public class MixedCaseNameCheck extends BaseCheck
+{
+
+    // You can use serialver to regenerate the serial UID.
+    private static final long serialVersionUID = 1L;
+
+    private static final HashSet<String> NON_BICAMERAL_LANGUAGE_COUNTRIES = new HashSet<>(Arrays
+            .asList("AFG", "DZA", "BHR", "BGD", "BLR", "BTN", "BRN", "KHM", "TCD", "CHN", "COM",
+                    "DJI", "EGY", "ERI", "ETH", "GEO", "IND", "IRN", "IRQ", "ISR", "JPN", "JOR",
+                    "KAZ", "KWT", "KGZ", "LAO", "LBN", "LBY", "MKD", "MYS", "MDV", "MRT", "MAR",
+                    "MMR", "NPL", "PRK", "OMN", "PAK", "PSE", "QAT", "SAU", "SGP", "SOM", "KOR",
+                    "LKA", "SDN", "SYR", "TWN", "TZA", "THA", "TUN", "UKR", "ARE", "ESH", "YEM"));
+
+    private static final List<String> LANGUAGE_NAME_TAGS_DEFAULT = Arrays.asList("name:en");
+    private static final List<String> LOWER_CASE_WORDS_DEFAULT = Arrays.asList("and", "to", "of");
+    private static final String SPECIAL_CHARACTERS_DEFAULT = "-/(&";
+    private static final List<String> NAME_AFFIXES_DEFAULT = Arrays.asList("Mc", "Mac", "Mck",
+            "Mhic", "Mic");
+
+    private final List<String> languageNameTags;
+    private final List<String> lowerCaseWords;
+    private final String specialCharacters;
+    private final String nameAffixes;
+
+    /**
+     * The default constructor that must be supplied. The Atlas Checks framework will generate the
+     * checks with this constructor, supplying a configuration that can be used to adjust any
+     * parameters that the check uses during operation.
+     *
+     * @param configuration
+     *            the JSON configuration for this check
+     */
+    public MixedCaseNameCheck(final Configuration configuration)
+    {
+        super(configuration);
+        this.languageNameTags = (List<String>) configurationValue(configuration,
+                "name.language.keys", LANGUAGE_NAME_TAGS_DEFAULT);
+        this.lowerCaseWords = (List<String>) configurationValue(configuration, "lower_case_words",
+                LOWER_CASE_WORDS_DEFAULT);
+        this.specialCharacters = (String) configurationValue(configuration,
+                "characters.capital.prefix", SPECIAL_CHARACTERS_DEFAULT);
+        this.nameAffixes = (String) configurationValue(configuration, "lower_case_words",
+                NAME_AFFIXES_DEFAULT, value -> String.join("|", (List<String>) value));
+    }
+
+    /**
+     * This function will validate if the supplied atlas object is valid for the check.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return {@code true} if this object should be checked
+     */
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return !(object instanceof Relation) && this.isFlagged(object.getOsmIdentifier())
+                && ((!NON_BICAMERAL_LANGUAGE_COUNTRIES
+                        .contains(object.tag(ISOCountryTag.KEY).toUpperCase())
+                        && Validators.hasValuesFor(object, NameTag.class))
+                        || languageNameTags.stream()
+                                .anyMatch(key -> object.getOsmTags().containsKey(key)));
+    }
+
+    /**
+     * This is the actual function that will check to see whether the object needs to be flagged.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return an optional {@link CheckFlag} object that
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final Map<String, String> osmTags = object.getOsmTags();
+        if (!NON_BICAMERAL_LANGUAGE_COUNTRIES.contains(object.tag(ISOCountryTag.KEY).toUpperCase()))
+        {
+
+        }
+        for (String key : languageNameTags)
+        {
+            if (osmTags.containsKey(key) && isMixedCase(osmTags.get(key)))
+            {
+
+            }
+
+        }
+        return Optional.empty();
+    }
+
+    private boolean isMixedCase(final String value)
+    {
+        // Split into words based on spaces
+        final String[] wordArray = value.split(" ");
+        // Check each word
+        for (String word : wordArray)
+        {
+            // If there is more than 1 word and the word is not in the lower case list: check that
+            // the first letter is a capital
+            if (wordArray.length > 1 && !lowerCaseWords.contains(word))
+            {
+                final Matcher firstLetterMatcher = Pattern.compile("\\p{L}").matcher(word);
+                firstLetterMatcher.find();
+                if (Character.isLowerCase(firstLetterMatcher.group().charAt(0)))
+                {
+                    return true;
+                }
+            }
+            // If the word is not all upper case: check if all the letters not following config
+            // specified characters and strings, and apostrophes, are lower case
+            if (Pattern.compile("[\\p{L}&&[^\\p{Lu}]]").matcher(word).find()
+                    && Pattern
+                            .compile(String.format(
+                                    "(\\p{L}.*(?<![\\Q%1$s\\E']|%2$s)(\\p{Lu}))|(\\p{L}.*(?<=')\\p{Lu}(?!.))",
+                                    this.specialCharacters, this.nameAffixes))
+                            .matcher(word).find())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -82,7 +82,7 @@ public class MixedCaseNameCheck extends BaseCheck
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return !(object instanceof Relation) && this.isFlagged(object.getOsmIdentifier())
+        return !(object instanceof Relation) && !this.isFlagged(object.getOsmIdentifier())
                 && ((!NON_BICAMERAL_LANGUAGE_COUNTRIES
                         .contains(object.tag(ISOCountryTag.KEY).toUpperCase())
                         && Validators.hasValuesFor(object, NameTag.class))
@@ -104,6 +104,7 @@ public class MixedCaseNameCheck extends BaseCheck
         final Map<String, String> osmTags = object.getOsmTags();
 
         if (!NON_BICAMERAL_LANGUAGE_COUNTRIES.contains(object.tag(ISOCountryTag.KEY).toUpperCase())
+                && Validators.hasValuesFor(object, NameTag.class)
                 && isMixedCase(osmTags.get(NameTag.KEY)))
         {
             mixedCaseNameTags.add("name");
@@ -133,6 +134,12 @@ public class MixedCaseNameCheck extends BaseCheck
                     object.getOsmIdentifier(), String.join(" ", mixedCaseNameTags))));
         }
         return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
     }
 
     private boolean isMixedCase(final String value)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -48,7 +48,7 @@ public class MixedCaseNameCheck extends BaseCheck
             "to", "of", "by", "upon", "on", "off", "at", "as", "into", "like", "near", "onto",
             "per", "till", "up", "via", "with");
     private static final List<String> LOWER_CASE_ARTICLES_DEFAULT = Arrays.asList("a", "an", "the");
-    private static final String SPLIT_CHARACTERS_DEFAULT = " -/(&@–";
+    private static final String SPLIT_CHARACTERS_DEFAULT = " -/()&@–";
     private static final List<String> NAME_AFFIXES_DEFAULT = Arrays.asList("Mc", "Mac", "Mck",
             "Mhic", "Mic");
 
@@ -174,18 +174,20 @@ public class MixedCaseNameCheck extends BaseCheck
      */
     private boolean isMixedCase(final String value)
     {
-        // Split into words based on spaces
+        // Split into words based on configurable characters
         final String[] wordArray = value.split("[\\Q" + this.splitCharacters + "\\E]");
         boolean firstWord = true;
         // Check each word
         for (final String word : wordArray)
         {
-            // If there is more than 1 word and the word is not in the lower case list: check that
+            // If there is more than 1 word, the word is not in the list of prepositions, and the
+            // word is not both in the article list and not the first word: check that
             // the first letter is a capital
             if (wordArray.length > 1 && !lowerCasePrepositions.contains(word)
                     && !(!firstWord && lowerCaseArticles.contains(word)))
             {
                 final Matcher firstLetterMatcher = Pattern.compile("\\p{L}").matcher(word);
+                // If the first letter is lower case: return true if it is not preceded by a number
                 if (firstLetterMatcher.find()
                         && Character.isLowerCase(firstLetterMatcher.group().charAt(0))
                         && !(firstLetterMatcher.start() != 0
@@ -194,8 +196,8 @@ public class MixedCaseNameCheck extends BaseCheck
                     return true;
                 }
             }
-            // If the word is not all upper case: check if all the letters not following config
-            // specified characters and strings, and apostrophes, are lower case
+            // If the word is not all upper case: check if all the letters not following
+            // apostrophes, unless at the end of the word, are lower case
             if (Pattern.compile("[\\p{L}&&[^\\p{Lu}]]").matcher(word).find() && Pattern.compile(
                     String.format("(\\p{L}.*(?<!'|%1$s)(\\p{Lu}))|(\\p{L}.*(?<=')\\p{Lu}(?!.))",
                             this.nameAffixes))

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -123,7 +123,7 @@ public class MixedCaseNameCheck extends BaseCheck
                 && Validators.hasValuesFor(object, NameTag.class)
                 && isMixedCase(osmTags.get(NameTag.KEY)))
         {
-            mixedCaseNameTags.add("name");
+            mixedCaseNameTags.add(NameTag.KEY);
         }
         // Check all language name tags
         for (final String key : languageNameTags)
@@ -139,19 +139,10 @@ public class MixedCaseNameCheck extends BaseCheck
         if (!mixedCaseNameTags.isEmpty())
         {
             this.markAsFlagged(object.getOsmIdentifier());
-            final String osmType;
-            // Get OSM type for object
-            if (object instanceof LocationItem)
-            {
-                osmType = "Node";
-            }
-            else
-            {
-                osmType = "Way";
-            }
             // Instruction includes type of OSM object and list of flagged tags
-            return Optional.of(this.createFlag(object, this.getLocalizedInstruction(0, osmType,
-                    object.getOsmIdentifier(), String.join(", ", mixedCaseNameTags))));
+            return Optional.of(this.createFlag(object,
+                    this.getLocalizedInstruction(0, object instanceof LocationItem ? "Node" : "Way",
+                            object.getOsmIdentifier(), String.join(", ", mixedCaseNameTags))));
         }
         return Optional.empty();
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -143,7 +143,7 @@ public class MixedCaseNameCheck extends BaseCheck
                 osmType = "Way";
             }
             return Optional.of(this.createFlag(object, this.getLocalizedInstruction(0, osmType,
-                    object.getOsmIdentifier(), String.join(" ", mixedCaseNameTags))));
+                    object.getOsmIdentifier(), String.join(", ", mixedCaseNameTags))));
         }
         return Optional.empty();
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -39,14 +39,14 @@ public class MixedCaseNameCheck extends BaseCheck
     // "LKA", "SDN", "SYR", "TWN", "TZA", "THA", "TUN", "UKR", "ARE", "ESH", "YEM"
 
     private static final List<String> CHECK_NAME_COUNTRIES_DEFAULT = Arrays.asList("AIA", "ATG",
-            "AUT", "BHS", "BRB", "BLZ", "BMU", "BWA", "VGB", "CMR", "CAN", "CYM", "DMA", "FJI",
+            "AUS", "BHS", "BRB", "BLZ", "BMU", "BWA", "VGB", "CMR", "CAN", "CYM", "DMA", "FJI",
             "GMB", "GHA", "GIB", "GRD", "GUY", "IRL", "JAM", "KEN", "LSO", "MWI", "MLT", "MUS",
             "MSR", "NAM", "NZL", "NGA", "PNG", "SYC", "SLE", "SGP", "SLB", "ZAF", "SWZ", "TZA",
             "TON", "TTO", "TCA", "UGA", "GBR", "USA", "VUT", "ZMB", "ZWE");
     private static final List<String> LANGUAGE_NAME_TAGS_DEFAULT = Arrays.asList("name:en");
     private static final List<String> LOWER_CASE_PREPOSITIONS_DEFAULT = Arrays.asList("and", "from",
             "to", "of", "by", "upon", "on", "off", "at", "as", "into", "like", "near", "onto",
-            "per", "till", "up", "via", "with");
+            "per", "till", "up", "via", "with", "for");
     private static final List<String> LOWER_CASE_ARTICLES_DEFAULT = Arrays.asList("a", "an", "the");
     private static final String SPLIT_CHARACTERS_DEFAULT = " -/()&@–";
     private static final List<String> NAME_AFFIXES_DEFAULT = Arrays.asList("Mc", "Mac", "Mck",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -98,11 +98,9 @@ public class MixedCaseNameCheck extends BaseCheck
     public boolean validCheckForObject(final AtlasObject object)
     {
         // Valid objects are items that were OSM nodes or ways
-        return !(object instanceof Relation)
-                && !this.isFlagged(object.getOsmIdentifier())
-                // Must have an ISO code tag...
+        return !(object instanceof Relation) && !this.isFlagged(object.getOsmIdentifier())
                 && ((object.getTags().containsKey(ISOCountryTag.KEY)
-                        // The ISO must be in checkNameCountries...
+                        // Must have an ISO code that is in checkNameCountries...
                         && this.checkNameCountries
                                 .contains(object.tag(ISOCountryTag.KEY).toUpperCase())
                         // And have a name tag

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -132,7 +132,6 @@ public class MixedCaseNameCheck extends BaseCheck
             {
                 mixedCaseNameTags.add(key);
             }
-
         }
 
         // If mix case id detected, flag

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -46,7 +46,7 @@ public class MixedCaseNameCheck extends BaseCheck
     private static final List<String> LANGUAGE_NAME_TAGS_DEFAULT = Arrays.asList("name:en");
     private static final List<String> LOWER_CASE_PREPOSITIONS_DEFAULT = Arrays.asList("and", "from",
             "to", "of", "by", "upon", "on", "off", "at", "as", "into", "like", "near", "onto",
-            "per", "till", "up", "via", "with", "for");
+            "per", "till", "up", "via", "with", "for", "in");
     private static final List<String> LOWER_CASE_ARTICLES_DEFAULT = Arrays.asList("a", "an", "the");
     private static final String SPLIT_CHARACTERS_DEFAULT = " -/()&@–";
     private static final List<String> NAME_AFFIXES_DEFAULT = Arrays.asList("Mc", "Mac", "Mck",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -30,14 +30,6 @@ public class MixedCaseNameCheck extends BaseCheck
 
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
             "{0} {1,number,#} has (an) invalid mixed-case value(s) for the following tag(s): {2}.");
-
-    // Non Bicameral Language Countries
-    // "AFG", "DZA", "BHR", "BGD", "BLR", "BTN", "BRN", "KHM", "TCD", "CHN", "COM",
-    // "DJI", "EGY", "ERI", "ETH", "GEO", "IND", "IRN", "IRQ", "ISR", "JPN", "JOR",
-    // "KAZ", "KWT", "KGZ", "LAO", "LBN", "LBY", "MKD", "MYS", "MDV", "MRT", "MAR",
-    // "MMR", "NPL", "PRK", "OMN", "PAK", "PSE", "QAT", "SAU", "SGP", "SOM", "KOR",
-    // "LKA", "SDN", "SYR", "TWN", "TZA", "THA", "TUN", "UKR", "ARE", "ESH", "YEM"
-
     private static final List<String> CHECK_NAME_COUNTRIES_DEFAULT = Arrays.asList("AIA", "ATG",
             "AUS", "BHS", "BRB", "BLZ", "BMU", "BWA", "VGB", "CMR", "CAN", "CYM", "DMA", "FJI",
             "GMB", "GHA", "GIB", "GRD", "GUY", "IRL", "JAM", "KEN", "LSO", "MWI", "MLT", "MUS",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -45,7 +45,7 @@ public class MixedCaseNameCheck extends BaseCheck
             "MSR", "NAM", "NZL", "NGA", "PNG", "SYC", "SLE", "SGP", "SLB", "ZAF", "SWZ", "TZA",
             "TON", "TTO", "TCA", "UGA", "GBR", "USA", "VUT", "ZMB", "ZWE");
     private static final List<String> LANGUAGE_NAME_TAGS_DEFAULT = Arrays.asList("name:en");
-    private static final List<String> LOWER_CASE_WORDS_DEFAULT = Arrays.asList("and", "to", "of");
+    private static final List<String> LOWER_CASE_WORDS_DEFAULT = Arrays.asList("and", "to", "of", "the");
     private static final String SPECIAL_CHARACTERS_DEFAULT = "-/(&";
     private static final List<String> NAME_AFFIXES_DEFAULT = Arrays.asList("Mc", "Mac", "Mck",
             "Mhic", "Mic");

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -76,14 +76,14 @@ public class MixedCaseNameCheck extends BaseCheck
         this.languageNameTags = (List<String>) configurationValue(configuration,
                 "name.language.keys", LANGUAGE_NAME_TAGS_DEFAULT);
         this.lowerCasePrepositions = (List<String>) configurationValue(configuration,
-                "lower_case.prepositions", LOWER_CASE_PREPOSITIONS_DEFAULT);
-        this.lowerCaseArticles = (List<String>) configurationValue(configuration,
-                "lower_case.articles", LOWER_CASE_ARTICLES_DEFAULT);
-        this.splitCharacters = (String) configurationValue(configuration, "words.split.characters",
+                "name.prepositions", LOWER_CASE_PREPOSITIONS_DEFAULT);
+        this.lowerCaseArticles = (List<String>) configurationValue(configuration, "name.articles",
+                LOWER_CASE_ARTICLES_DEFAULT);
+        this.splitCharacters = (String) configurationValue(configuration, "regex.split",
                 SPLIT_CHARACTERS_DEFAULT);
-        this.nameAffixes = (String) configurationValue(configuration, "name_affixes",
+        this.nameAffixes = (String) configurationValue(configuration, "name.affixes",
                 NAME_AFFIXES_DEFAULT, value -> String.join("|", (List<String>) value));
-        this.mixedCaseUnits = (String) configurationValue(configuration, "units.mixed_case",
+        this.mixedCaseUnits = (String) configurationValue(configuration, "name.units",
                 MIXED_CASE_UNITS_DEFAULT, value -> String.join("|", (List<String>) value));
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -178,27 +178,25 @@ public class MixedCaseNameCheck extends BaseCheck
                 // Check if the word is intentionally mixed case
                 if (!isMixedCaseUnit(word))
                 {
+                    final Matcher firstLetterMatcher = Pattern.compile("\\p{L}").matcher(word);
                     // If the word is not in the list of prepositions, and the
                     // word is not both in the article list and not the first word: check that
                     // the first letter is a capital
-                    if (!this.lowerCasePrepositions.contains(word)
-                            && !(!firstWord && this.lowerCaseArticles.contains(word)))
-                    {
-                        final Matcher firstLetterMatcher = Pattern.compile("\\p{L}").matcher(word);
-                        // If the first letter is lower case: return true if it is not preceded by a
-                        // number
-                        if (firstLetterMatcher.find()
-                                && Character.isLowerCase(firstLetterMatcher.group().charAt(0))
-                                && !(firstLetterMatcher.start() != 0 && Character
-                                        .isDigit(word.charAt(firstLetterMatcher.start() - 1))))
-                        {
-                            return true;
-                        }
-                    }
-                    // If the word is not all upper case: check if all the letters not following
-                    // apostrophes, unless at the end of the word, are lower case
-                    if (Pattern.compile("\\p{Ll}").matcher(word).find()
-                            && !isMixedCaseApostrophe(word) && isProperNonFirstCapital(word))
+                    if ((!this.lowerCasePrepositions.contains(word)
+                            && !(!firstWord && this.lowerCaseArticles.contains(word))
+                            // If the first letter is lower case: return true if it is not preceded
+                            // by a
+                            // number
+                            && firstLetterMatcher.find()
+                            && Character.isLowerCase(firstLetterMatcher.group().charAt(0))
+                            && !(firstLetterMatcher.start() != 0 && Character
+                                    .isDigit(word.charAt(firstLetterMatcher.start() - 1))))
+                            // If the word is not all upper case: check if all the letters not
+                            // following
+                            // apostrophes, unless at the end of the word, are lower case
+                            || (Pattern.compile("\\p{Ll}").matcher(word).find()
+                                    && !isMixedCaseApostrophe(word)
+                                    && isProperNonFirstCapital(word)))
                     {
                         return true;
                     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -19,15 +19,14 @@ import org.openstreetmap.atlas.tags.names.NameTag;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
- * This check flags objects with {@code name} tags that improperly use mixed cases.
+ * This check flags objects with name tags that improperly use mixed cases.
  *
  * @author bbreithaupt
  */
 public class MixedCaseNameCheck extends BaseCheck
 {
 
-    // You can use serialver to regenerate the serial UID.
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 7109483897229499466L;
 
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
             "{0} {1,number,#} has (an) invalid mixed-case value(s) for the following tag(s): {2}.");
@@ -45,7 +44,8 @@ public class MixedCaseNameCheck extends BaseCheck
             "MSR", "NAM", "NZL", "NGA", "PNG", "SYC", "SLE", "SGP", "SLB", "ZAF", "SWZ", "TZA",
             "TON", "TTO", "TCA", "UGA", "GBR", "USA", "VUT", "ZMB", "ZWE");
     private static final List<String> LANGUAGE_NAME_TAGS_DEFAULT = Arrays.asList("name:en");
-    private static final List<String> LOWER_CASE_WORDS_DEFAULT = Arrays.asList("and", "to", "of", "the");
+    private static final List<String> LOWER_CASE_WORDS_DEFAULT = Arrays.asList("and", "to", "of",
+            "the");
     private static final String SPECIAL_CHARACTERS_DEFAULT = "-/(&";
     private static final List<String> NAME_AFFIXES_DEFAULT = Arrays.asList("Mc", "Mac", "Mck",
             "Mhic", "Mic");
@@ -115,12 +115,14 @@ public class MixedCaseNameCheck extends BaseCheck
         final List<String> mixedCaseNameTags = new ArrayList<>();
         final Map<String, String> osmTags = object.getOsmTags();
 
+        // Check ISO against list of countries for testing name tag
         if (checkNameCountries.contains(object.tag(ISOCountryTag.KEY).toUpperCase())
                 && Validators.hasValuesFor(object, NameTag.class)
                 && isMixedCase(osmTags.get(NameTag.KEY)))
         {
             mixedCaseNameTags.add("name");
         }
+        // Check all language name tags
         for (final String key : languageNameTags)
         {
             if (osmTags.containsKey(key) && isMixedCase(osmTags.get(key)))
@@ -130,10 +132,12 @@ public class MixedCaseNameCheck extends BaseCheck
 
         }
 
+        // If mix case id detected, flag
         if (!mixedCaseNameTags.isEmpty())
         {
             this.markAsFlagged(object.getOsmIdentifier());
             final String osmType;
+            // Get OSM type for object
             if (object instanceof LocationItem)
             {
                 osmType = "Node";
@@ -142,6 +146,7 @@ public class MixedCaseNameCheck extends BaseCheck
             {
                 osmType = "Way";
             }
+            // Instruction includes type of OSM object and list of flagged tags
             return Optional.of(this.createFlag(object, this.getLocalizedInstruction(0, osmType,
                     object.getOsmIdentifier(), String.join(", ", mixedCaseNameTags))));
         }
@@ -155,8 +160,11 @@ public class MixedCaseNameCheck extends BaseCheck
     }
 
     /**
+     * Tests each word in a string for proper use of case in a name.
+     *
      * @param value
-     * @return
+     *            String to check
+     * @return true when there is improper case in any of the words
      */
     private boolean isMixedCase(final String value)
     {

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTest.java
@@ -21,7 +21,7 @@ public class MixedCaseNameCheckTest
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
     private final Configuration inlineConfiguration = ConfigurationResolver.inlineConfiguration(
-            "{\"MixedCaseNameCheck\":{\"check_name.countries\":[\"USA\",\"GRC\"],\"name.language.keys\":[\"name:en\",\"name:el\"],\"lower_case\":{\"prepositions\":[\"and\", \"to\", \"of\"],\"articles\":[\"a\", \"an\", \"the\"]},\"words.split.characters\":\" -/&@\",\"name_affixes\":[\"Mc\", \"Mac\", \"Mck\",\"Mhic\", \"Mic\"]}}");
+            "{\"MixedCaseNameCheck\":{\"check_name.countries\":[\"USA\",\"GRC\"],\"name.language.keys\":[\"name:en\",\"name:el\"],\"lower_case\":{\"prepositions\":[\"and\", \"to\", \"of\"],\"articles\":[\"a\", \"an\", \"the\"]},\"words.split.characters\":\" -/&@\",\"name_affixes\":[\"Mc\", \"Mac\", \"Mck\",\"Mhic\", \"Mic\"],\"units.mixed_case\":[\"kV\"]}}");
 
     @Test
     public void invalidNamePointTest()
@@ -205,6 +205,14 @@ public class MixedCaseNameCheckTest
         this.verifier.actual(this.setup.invalidNamePointLowerCaseArticleStartAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void validNamePointMixedCaseUnitTest()
+    {
+        this.verifier.actual(this.setup.validNamePointMixedCaseUnitAtlas(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTest.java
@@ -24,241 +24,241 @@ public class MixedCaseNameCheckTest
             "{\"MixedCaseNameCheck\":{\"check_name.countries\":[\"USA\",\"GRC\"],\"name.language.keys\":[\"name:en\",\"name:el\"],\"lower_case\":{\"prepositions\":[\"and\", \"to\", \"of\"],\"articles\":[\"a\", \"an\", \"the\"]},\"words.split.characters\":\" -/(&@\",\"name_affixes\":[\"Mc\", \"Mac\", \"Mck\",\"Mhic\", \"Mic\"]}}");
 
     @Test
-    public void invalidNamePoint()
+    public void invalidNamePointTest()
     {
-        this.verifier.actual(this.setup.invalidNamePoint(),
+        this.verifier.actual(this.setup.invalidNamePointAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void invalidNameNode()
+    public void invalidNameNodeTest()
     {
-        this.verifier.actual(this.setup.invalidNameNode(),
+        this.verifier.actual(this.setup.invalidNameNodeAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void invalidNameLine()
+    public void invalidNameLineTest()
     {
-        this.verifier.actual(this.setup.invalidNameLine(),
+        this.verifier.actual(this.setup.invalidNameLineAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void invalidNameArea()
+    public void invalidNameAreaTest()
     {
-        this.verifier.actual(this.setup.invalidNameArea(),
+        this.verifier.actual(this.setup.invalidNameAreaAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void invalidNameEdge()
+    public void invalidNameEdgeTest()
     {
-        this.verifier.actual(this.setup.invalidNameEdge(),
+        this.verifier.actual(this.setup.invalidNameEdgeAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void invalidNamePointOneWord()
+    public void invalidNamePointOneWordTest()
     {
-        this.verifier.actual(this.setup.invalidNamePointOneWord(),
+        this.verifier.actual(this.setup.invalidNamePointOneWordAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void validNamePointHyphen()
+    public void validNamePointHyphenTest()
     {
-        this.verifier.actual(this.setup.validNamePointHyphen(),
+        this.verifier.actual(this.setup.validNamePointHyphenAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void validNamePointNumber()
+    public void validNamePointNumberTest()
     {
-        this.verifier.actual(this.setup.validNamePointNumber(),
+        this.verifier.actual(this.setup.validNamePointNumberAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void invalidNamePointHyphen()
+    public void invalidNamePointHyphenTest()
     {
-        this.verifier.actual(this.setup.invalidNamePointHyphen(),
+        this.verifier.actual(this.setup.invalidNamePointHyphenAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void validNamePointAffix()
+    public void validNamePointAffixTest()
     {
-        this.verifier.actual(this.setup.validNamePointAffix(),
+        this.verifier.actual(this.setup.validNamePointAffixAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void invalidNamePointAffix()
+    public void invalidNamePointAffixTest()
     {
-        this.verifier.actual(this.setup.invalidNamePointAffix(),
+        this.verifier.actual(this.setup.invalidNamePointAffixAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void validNamePointApostrophe()
+    public void validNamePointApostropheTest()
     {
-        this.verifier.actual(this.setup.validNamePointApostrophe(),
+        this.verifier.actual(this.setup.validNamePointApostropheAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void validNamePointApostropheLower()
+    public void validNamePointApostropheLowerTest()
     {
-        this.verifier.actual(this.setup.validNamePointApostropheLower(),
+        this.verifier.actual(this.setup.validNamePointApostropheLowerAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void validNamePointApostropheAllCaps()
+    public void validNamePointApostropheAllCapsTest()
     {
-        this.verifier.actual(this.setup.validNamePointApostropheAllCaps(),
+        this.verifier.actual(this.setup.validNamePointApostropheAllCapsAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void validNamePointCapsApostrophe()
+    public void validNamePointCapsApostropheTest()
     {
-        this.verifier.actual(this.setup.validNamePointCapsApostrophe(),
+        this.verifier.actual(this.setup.validNamePointCapsApostropheAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void validNamePointCapsLowerApostrophe()
+    public void validNamePointCapsLowerApostropheTest()
     {
-        this.verifier.actual(this.setup.validNamePointCapsLowerApostrophe(),
+        this.verifier.actual(this.setup.validNamePointCapsLowerApostropheAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void invalidNamePointApostrophe()
+    public void invalidNamePointApostropheTest()
     {
-        this.verifier.actual(this.setup.invalidNamePointApostrophe(),
+        this.verifier.actual(this.setup.invalidNamePointApostropheAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void validNamePointAllCaps()
+    public void validNamePointAllCapsTest()
     {
-        this.verifier.actual(this.setup.validNamePointAllCaps(),
+        this.verifier.actual(this.setup.validNamePointAllCapsAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void validNamePointNoCaps()
+    public void validNamePointNoCapsTest()
     {
-        this.verifier.actual(this.setup.validNamePointNoCaps(),
+        this.verifier.actual(this.setup.validNamePointNoCapsAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void validNamePointLowerCasePreposition()
+    public void validNamePointLowerCasePrepositionTest()
     {
-        this.verifier.actual(this.setup.validNamePointLowerCasePreposition(),
+        this.verifier.actual(this.setup.validNamePointLowerCasePrepositionAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void validNamePointLowerCaseArticle()
+    public void validNamePointLowerCaseArticleTest()
     {
-        this.verifier.actual(this.setup.validNamePointLowerCaseArticle(),
+        this.verifier.actual(this.setup.validNamePointLowerCaseArticleAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void validNamePointLowerCaseArticleStart()
+    public void validNamePointLowerCaseArticleStartTest()
     {
-        this.verifier.actual(this.setup.validNamePointLowerCaseArticleStart(),
+        this.verifier.actual(this.setup.validNamePointLowerCaseArticleStartAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void invalidNamePointLowerCaseArticleStart()
+    public void invalidNamePointLowerCaseArticleStartTest()
     {
-        this.verifier.actual(this.setup.invalidNamePointLowerCaseArticleStart(),
+        this.verifier.actual(this.setup.invalidNamePointLowerCaseArticleStartAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void invalidNamePointEn()
+    public void invalidNamePointEnTest()
     {
-        this.verifier.actual(this.setup.invalidNamePointEn(),
+        this.verifier.actual(this.setup.invalidNamePointEnAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void invalidNamePointGreek()
+    public void invalidNamePointGreekTest()
     {
-        this.verifier.actual(this.setup.invalidNamePointGreek(),
+        this.verifier.actual(this.setup.invalidNamePointGreekAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void validNamePointGreek()
+    public void validNamePointGreekTest()
     {
-        this.verifier.actual(this.setup.validNamePointGreek(),
+        this.verifier.actual(this.setup.validNamePointGreekAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void invalidNamePointGreekEl()
+    public void invalidNamePointGreekElTest()
     {
-        this.verifier.actual(this.setup.invalidNamePointGreekEl(),
+        this.verifier.actual(this.setup.invalidNamePointGreekElAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void validNamePointGreekEl()
+    public void validNamePointGreekElTest()
     {
-        this.verifier.actual(this.setup.validNamePointGreekEl(),
+        this.verifier.actual(this.setup.validNamePointGreekElAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void invalidNamePointChn()
+    public void invalidNamePointChnTest()
     {
-        this.verifier.actual(this.setup.invalidNamePointChn(),
+        this.verifier.actual(this.setup.invalidNamePointChnAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void validNamePointChn()
+    public void validNamePointChnTest()
     {
-        this.verifier.actual(this.setup.validNamePointChn(),
+        this.verifier.actual(this.setup.validNamePointChnAtlas(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTest.java
@@ -21,7 +21,7 @@ public class MixedCaseNameCheckTest
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
     private final Configuration inlineConfiguration = ConfigurationResolver.inlineConfiguration(
-            "{\"MixedCaseNameCheck\":{\"check_name.countries\":[\"USA\",\"GRC\"],\"name.language.keys\":[\"name:en\",\"name:el\"],\"lower_case_words\":[\"and\", \"to\", \"of\"],\"characters.capital.prefix\":\"-/(&\",\"name_affixes\":[\"Mc\", \"Mac\", \"Mck\",\"Mhic\", \"Mic\"]}}");
+            "{\"MixedCaseNameCheck\":{\"check_name.countries\":[\"USA\",\"GRC\"],\"name.language.keys\":[\"name:en\",\"name:el\"],\"lower_case\":{\"prepositions\":[\"and\", \"to\", \"of\"],\"articles\":[\"a\", \"an\", \"the\"]},\"words.split.characters\":\" -/(&@\",\"name_affixes\":[\"Mc\", \"Mac\", \"Mck\",\"Mhic\", \"Mic\"]}}");
 
     @Test
     public void invalidNamePoint()
@@ -75,6 +75,14 @@ public class MixedCaseNameCheckTest
     public void validNamePointHyphen()
     {
         this.verifier.actual(this.setup.validNamePointHyphen(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointNumber()
+    {
+        this.verifier.actual(this.setup.validNamePointNumber(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
@@ -152,11 +160,35 @@ public class MixedCaseNameCheckTest
     }
 
     @Test
-    public void validNamePointLowerCaseWord()
+    public void validNamePointLowerCasePreposition()
     {
-        this.verifier.actual(this.setup.validNamePointLowerCaseWord(),
+        this.verifier.actual(this.setup.validNamePointLowerCasePreposition(),
                 new MixedCaseNameCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointLowerCaseArticle()
+    {
+        this.verifier.actual(this.setup.validNamePointLowerCaseArticle(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointLowerCaseArticleStart()
+    {
+        this.verifier.actual(this.setup.validNamePointLowerCaseArticleStart(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void invalidNamePointLowerCaseArticleStart()
+    {
+        this.verifier.actual(this.setup.invalidNamePointLowerCaseArticleStart(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTest.java
@@ -21,7 +21,7 @@ public class MixedCaseNameCheckTest
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
     private final Configuration inlineConfiguration = ConfigurationResolver.inlineConfiguration(
-            "{\"MixedCaseNameCheck\":{\"check_name.countries\":[\"USA\",\"GRC\"],\"name.language.keys\":[\"name:en\",\"name:el\"],\"lower_case\":{\"prepositions\":[\"and\", \"to\", \"of\"],\"articles\":[\"a\", \"an\", \"the\"]},\"words.split.characters\":\" -/(&@\",\"name_affixes\":[\"Mc\", \"Mac\", \"Mck\",\"Mhic\", \"Mic\"]}}");
+            "{\"MixedCaseNameCheck\":{\"check_name.countries\":[\"USA\",\"GRC\"],\"name.language.keys\":[\"name:en\",\"name:el\"],\"lower_case\":{\"prepositions\":[\"and\", \"to\", \"of\"],\"articles\":[\"a\", \"an\", \"the\"]},\"words.split.characters\":\" -/&@\",\"name_affixes\":[\"Mc\", \"Mac\", \"Mck\",\"Mhic\", \"Mic\"]}}");
 
     @Test
     public void invalidNamePointTest()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTest.java
@@ -1,6 +1,217 @@
-import static org.junit.Assert.*;
+package org.openstreetmap.atlas.checks.validation.tag;
 
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * Tests for {@link MixedCaseNameCheck}
+ *
+ * @author bbreithaupt
+ */
 public class MixedCaseNameCheckTest
 {
+    @Rule
+    public MixedCaseNameCheckTestRule setup = new MixedCaseNameCheckTestRule();
 
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    private final Configuration inlineConfiguration = ConfigurationResolver.inlineConfiguration(
+            "{\"MixedCaseNameCheck\":{\"check_name.countries\":[\"USA\",\"GRC\"],\"name.language.keys\":[\"name:en\",\"name:el\"],\"lower_case_words\":[\"and\", \"to\", \"of\"],\"characters.capital.prefix\":\"-/(&\",\"name_affixes\":[\"Mc\", \"Mac\", \"Mck\",\"Mhic\", \"Mic\"]}}");
+
+    @Test
+    public void invalidNamePoint()
+    {
+        this.verifier.actual(this.setup.invalidNamePoint(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void invalidNameNode()
+    {
+        this.verifier.actual(this.setup.invalidNameNode(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void invalidNameLine()
+    {
+        this.verifier.actual(this.setup.invalidNameLine(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void invalidNameArea()
+    {
+        this.verifier.actual(this.setup.invalidNameArea(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void invalidNameEdge()
+    {
+        this.verifier.actual(this.setup.invalidNameEdge(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void invalidNamePointOneWord()
+    {
+        this.verifier.actual(this.setup.invalidNamePointOneWord(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void validNamePointHyphen()
+    {
+        this.verifier.actual(this.setup.validNamePointHyphen(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void invalidNamePointHyphen()
+    {
+        this.verifier.actual(this.setup.invalidNamePointHyphen(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void validNamePointAffix()
+    {
+        this.verifier.actual(this.setup.validNamePointAffix(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void invalidNamePointAffix()
+    {
+        this.verifier.actual(this.setup.invalidNamePointAffix(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void validNamePointApostrophe()
+    {
+        this.verifier.actual(this.setup.validNamePointApostrophe(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointApostropheLower()
+    {
+        this.verifier.actual(this.setup.validNamePointApostropheLower(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointApostropheAllCaps()
+    {
+        this.verifier.actual(this.setup.validNamePointApostropheAllCaps(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void invalidNamePointApostrophe()
+    {
+        this.verifier.actual(this.setup.invalidNamePointApostrophe(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void validNamePointAllCaps()
+    {
+        this.verifier.actual(this.setup.validNamePointAllCaps(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointNoCaps()
+    {
+        this.verifier.actual(this.setup.validNamePointNoCaps(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointLowerCaseWord()
+    {
+        this.verifier.actual(this.setup.validNamePointLowerCaseWord(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void invalidNamePointEn()
+    {
+        this.verifier.actual(this.setup.invalidNamePointEn(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void invalidNamePointGreek()
+    {
+        this.verifier.actual(this.setup.invalidNamePointGreek(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void validNamePointGreek()
+    {
+        this.verifier.actual(this.setup.validNamePointGreek(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void invalidNamePointGreekEl()
+    {
+        this.verifier.actual(this.setup.invalidNamePointGreekEl(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void validNamePointGreekEl()
+    {
+        this.verifier.actual(this.setup.validNamePointGreekEl(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void invalidNamePointChn()
+    {
+        this.verifier.actual(this.setup.invalidNamePointChn(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void validNamePointChn()
+    {
+        this.verifier.actual(this.setup.validNamePointChn(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTest.java
@@ -1,0 +1,6 @@
+import static org.junit.Assert.*;
+
+public class MixedCaseNameCheckTest
+{
+
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTest.java
@@ -136,6 +136,22 @@ public class MixedCaseNameCheckTest
     }
 
     @Test
+    public void validNamePointCapsApostrophe()
+    {
+        this.verifier.actual(this.setup.validNamePointCapsApostrophe(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointCapsLowerApostrophe()
+    {
+        this.verifier.actual(this.setup.validNamePointCapsLowerApostrophe(),
+                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
     public void invalidNamePointApostrophe()
     {
         this.verifier.actual(this.setup.invalidNamePointApostrophe(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTestRule.java
@@ -25,25 +25,25 @@ public class MixedCaseNameCheckTestRule extends CoreTestRule
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=tEst TeSt" }) })
-    private Atlas invalidNamePoint;
+    private Atlas invalidNamePointAtlas;
 
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=tEst TeSt" }) })
-    private Atlas invalidNameNode;
+    private Atlas invalidNameNodeAtlas;
 
     @TestAtlas(
             // Lines
             lines = { @Line(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                     @Loc(value = TEST_3) }, tags = { "iso_country_code=USA", "name=tEst TeSt" }) })
-    private Atlas invalidNameLine;
+    private Atlas invalidNameLineAtlas;
 
     @TestAtlas(
             // Areas
             areas = { @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                     @Loc(value = TEST_3) }, tags = { "iso_country_code=USA", "name=tEst TeSt" }) })
-    private Atlas invalidNameArea;
+    private Atlas invalidNameAreaAtlas;
 
     @TestAtlas(
             // nodes
@@ -52,305 +52,305 @@ public class MixedCaseNameCheckTestRule extends CoreTestRule
             // edges
             edges = { @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                     @Loc(value = TEST_3) }, tags = { "iso_country_code=USA", "name=tEst TeSt" }) })
-    private Atlas invalidNameEdge;
+    private Atlas invalidNameEdgeAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=tEst" }) })
-    private Atlas invalidNamePointOneWord;
+    private Atlas invalidNamePointOneWordAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=Test-Test" }) })
-    private Atlas validNamePointHyphen;
+    private Atlas validNamePointHyphenAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=2test Test" }) })
-    private Atlas validNamePointNumber;
+    private Atlas validNamePointNumberAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=Test-TesT" }) })
-    private Atlas invalidNamePointHyphen;
+    private Atlas invalidNamePointHyphenAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=McMan" }) })
-    private Atlas validNamePointAffix;
+    private Atlas validNamePointAffixAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=McMaN" }) })
-    private Atlas invalidNamePointAffix;
+    private Atlas invalidNamePointAffixAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=O'Flanagan" }) })
-    private Atlas validNamePointApostrophe;
+    private Atlas validNamePointApostropheAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=Scott's" }) })
-    private Atlas validNamePointApostropheLower;
+    private Atlas validNamePointApostropheLowerAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=SCOTT'S" }) })
-    private Atlas validNamePointApostropheAllCaps;
+    private Atlas validNamePointApostropheAllCapsAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=SCOTT's" }) })
-    private Atlas validNamePointCapsApostrophe;
+    private Atlas validNamePointCapsApostropheAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=SCOTTs'" }) })
-    private Atlas validNamePointCapsLowerApostrophe;
+    private Atlas validNamePointCapsLowerApostropheAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=Scott'S" }) })
-    private Atlas invalidNamePointApostrophe;
+    private Atlas invalidNamePointApostropheAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=TEST" }) })
-    private Atlas validNamePointAllCaps;
+    private Atlas validNamePointAllCapsAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=test" }) })
-    private Atlas validNamePointNoCaps;
+    private Atlas validNamePointNoCapsAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=Test of Test" }) })
-    private Atlas validNamePointLowerCasePreposition;
+    private Atlas validNamePointLowerCasePrepositionAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=Test a Test" }) })
-    private Atlas validNamePointLowerCaseArticle;
+    private Atlas validNamePointLowerCaseArticleAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=A Test" }) })
-    private Atlas validNamePointLowerCaseArticleStart;
+    private Atlas validNamePointLowerCaseArticleStartAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=a Test" }) })
-    private Atlas invalidNamePointLowerCaseArticleStart;
+    private Atlas invalidNamePointLowerCaseArticleStartAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name:en=tEst TeSt" }) })
-    private Atlas invalidNamePointEn;
+    private Atlas invalidNamePointEnAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=GRC",
                     "name=τΕστ ΤεΣτ" }) })
-    private Atlas invalidNamePointGreek;
+    private Atlas invalidNamePointGreekAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=GRC",
                     "name=Τεστ Τεστ" }) })
-    private Atlas validNamePointGreek;
+    private Atlas validNamePointGreekAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=GRC",
                     "name:el=τΕστ ΤεΣτ" }) })
-    private Atlas invalidNamePointGreekEl;
+    private Atlas invalidNamePointGreekElAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=GRC",
                     "name:el=Τεστ Τεστ" }) })
-    private Atlas validNamePointGreekEl;
+    private Atlas validNamePointGreekElAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=CHN",
                     "name:en=tEst TeSt", "name=Test of Test" }) })
-    private Atlas invalidNamePointChn;
+    private Atlas invalidNamePointChnAtlas;
 
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=CHN",
                     "name:en=Test of Test", "name=tEst TeSt" }) })
-    private Atlas validNamePointChn;
+    private Atlas validNamePointChnAtlas;
 
-    public Atlas invalidNamePoint()
+    public Atlas invalidNamePointAtlas()
     {
-        return this.invalidNamePoint;
+        return this.invalidNamePointAtlas;
     }
 
-    public Atlas invalidNameNode()
+    public Atlas invalidNameNodeAtlas()
     {
-        return this.invalidNameNode;
+        return this.invalidNameNodeAtlas;
     }
 
-    public Atlas invalidNameLine()
+    public Atlas invalidNameLineAtlas()
     {
-        return this.invalidNameLine;
+        return this.invalidNameLineAtlas;
     }
 
-    public Atlas invalidNameArea()
+    public Atlas invalidNameAreaAtlas()
     {
-        return this.invalidNameArea;
+        return this.invalidNameAreaAtlas;
     }
 
-    public Atlas invalidNameEdge()
+    public Atlas invalidNameEdgeAtlas()
     {
-        return this.invalidNameEdge;
+        return this.invalidNameEdgeAtlas;
     }
 
-    public Atlas invalidNamePointOneWord()
+    public Atlas invalidNamePointOneWordAtlas()
     {
-        return this.invalidNamePointOneWord;
+        return this.invalidNamePointOneWordAtlas;
     }
 
-    public Atlas validNamePointHyphen()
+    public Atlas validNamePointHyphenAtlas()
     {
-        return this.validNamePointHyphen;
+        return this.validNamePointHyphenAtlas;
     }
 
-    public Atlas validNamePointNumber()
+    public Atlas validNamePointNumberAtlas()
     {
-        return this.validNamePointNumber;
+        return this.validNamePointNumberAtlas;
     }
 
-    public Atlas invalidNamePointHyphen()
+    public Atlas invalidNamePointHyphenAtlas()
     {
-        return this.invalidNamePointHyphen;
+        return this.invalidNamePointHyphenAtlas;
     }
 
-    public Atlas validNamePointAffix()
+    public Atlas validNamePointAffixAtlas()
     {
-        return this.validNamePointAffix;
+        return this.validNamePointAffixAtlas;
     }
 
-    public Atlas invalidNamePointAffix()
+    public Atlas invalidNamePointAffixAtlas()
     {
-        return this.invalidNamePointAffix;
+        return this.invalidNamePointAffixAtlas;
     }
 
-    public Atlas validNamePointApostrophe()
+    public Atlas validNamePointApostropheAtlas()
     {
-        return this.validNamePointApostrophe;
+        return this.validNamePointApostropheAtlas;
     }
 
-    public Atlas validNamePointApostropheLower()
+    public Atlas validNamePointApostropheLowerAtlas()
     {
-        return this.validNamePointApostropheLower;
+        return this.validNamePointApostropheLowerAtlas;
     }
 
-    public Atlas validNamePointApostropheAllCaps()
+    public Atlas validNamePointApostropheAllCapsAtlas()
     {
-        return this.validNamePointApostropheAllCaps;
+        return this.validNamePointApostropheAllCapsAtlas;
     }
 
-    public Atlas validNamePointCapsApostrophe()
+    public Atlas validNamePointCapsApostropheAtlas()
     {
-        return this.validNamePointCapsApostrophe;
+        return this.validNamePointCapsApostropheAtlas;
     }
 
-    public Atlas validNamePointCapsLowerApostrophe()
+    public Atlas validNamePointCapsLowerApostropheAtlas()
     {
-        return this.validNamePointCapsLowerApostrophe;
+        return this.validNamePointCapsLowerApostropheAtlas;
     }
 
-    public Atlas invalidNamePointApostrophe()
+    public Atlas invalidNamePointApostropheAtlas()
     {
-        return this.invalidNamePointApostrophe;
+        return this.invalidNamePointApostropheAtlas;
     }
 
-    public Atlas validNamePointAllCaps()
+    public Atlas validNamePointAllCapsAtlas()
     {
-        return this.validNamePointAllCaps;
+        return this.validNamePointAllCapsAtlas;
     }
 
-    public Atlas validNamePointNoCaps()
+    public Atlas validNamePointNoCapsAtlas()
     {
-        return this.validNamePointNoCaps;
+        return this.validNamePointNoCapsAtlas;
     }
 
-    public Atlas validNamePointLowerCasePreposition()
+    public Atlas validNamePointLowerCasePrepositionAtlas()
     {
-        return this.validNamePointLowerCasePreposition;
+        return this.validNamePointLowerCasePrepositionAtlas;
     }
 
-    public Atlas validNamePointLowerCaseArticle()
+    public Atlas validNamePointLowerCaseArticleAtlas()
     {
-        return this.validNamePointLowerCaseArticle;
+        return this.validNamePointLowerCaseArticleAtlas;
     }
 
-    public Atlas validNamePointLowerCaseArticleStart()
+    public Atlas validNamePointLowerCaseArticleStartAtlas()
     {
-        return this.validNamePointLowerCaseArticleStart;
+        return this.validNamePointLowerCaseArticleStartAtlas;
     }
 
-    public Atlas invalidNamePointLowerCaseArticleStart()
+    public Atlas invalidNamePointLowerCaseArticleStartAtlas()
     {
-        return this.invalidNamePointLowerCaseArticleStart;
+        return this.invalidNamePointLowerCaseArticleStartAtlas;
     }
 
-    public Atlas invalidNamePointEn()
+    public Atlas invalidNamePointEnAtlas()
     {
-        return this.invalidNamePointEn;
+        return this.invalidNamePointEnAtlas;
     }
 
-    public Atlas invalidNamePointGreek()
+    public Atlas invalidNamePointGreekAtlas()
     {
-        return this.invalidNamePointGreek;
+        return this.invalidNamePointGreekAtlas;
     }
 
-    public Atlas validNamePointGreek()
+    public Atlas validNamePointGreekAtlas()
     {
-        return this.validNamePointGreek;
+        return this.validNamePointGreekAtlas;
     }
 
-    public Atlas invalidNamePointGreekEl()
+    public Atlas invalidNamePointGreekElAtlas()
     {
-        return this.invalidNamePointGreekEl;
+        return this.invalidNamePointGreekElAtlas;
     }
 
-    public Atlas validNamePointGreekEl()
+    public Atlas validNamePointGreekElAtlas()
     {
-        return this.validNamePointGreekEl;
+        return this.validNamePointGreekElAtlas;
     }
 
-    public Atlas invalidNamePointChn()
+    public Atlas invalidNamePointChnAtlas()
     {
-        return this.invalidNamePointChn;
+        return this.invalidNamePointChnAtlas;
     }
 
-    public Atlas validNamePointChn()
+    public Atlas validNamePointChnAtlas()
     {
-        return this.validNamePointChn;
+        return this.validNamePointChnAtlas;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTestRule.java
@@ -69,6 +69,12 @@ public class MixedCaseNameCheckTestRule extends CoreTestRule
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=2test Test" }) })
+    private Atlas validNamePointNumber;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=Test-TesT" }) })
     private Atlas invalidNamePointHyphen;
 
@@ -124,7 +130,25 @@ public class MixedCaseNameCheckTestRule extends CoreTestRule
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=Test of Test" }) })
-    private Atlas validNamePointLowerCaseWord;
+    private Atlas validNamePointLowerCasePreposition;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=Test a Test" }) })
+    private Atlas validNamePointLowerCaseArticle;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=A Test" }) })
+    private Atlas validNamePointLowerCaseArticleStart;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=a Test" }) })
+    private Atlas invalidNamePointLowerCaseArticleStart;
 
     @TestAtlas(
             // points
@@ -203,6 +227,11 @@ public class MixedCaseNameCheckTestRule extends CoreTestRule
         return this.validNamePointHyphen;
     }
 
+    public Atlas validNamePointNumber()
+    {
+        return this.validNamePointNumber;
+    }
+
     public Atlas invalidNamePointHyphen()
     {
         return this.invalidNamePointHyphen;
@@ -248,9 +277,24 @@ public class MixedCaseNameCheckTestRule extends CoreTestRule
         return this.validNamePointNoCaps;
     }
 
-    public Atlas validNamePointLowerCaseWord()
+    public Atlas validNamePointLowerCasePreposition()
     {
-        return this.validNamePointLowerCaseWord;
+        return this.validNamePointLowerCasePreposition;
+    }
+
+    public Atlas validNamePointLowerCaseArticle()
+    {
+        return this.validNamePointLowerCaseArticle;
+    }
+
+    public Atlas validNamePointLowerCaseArticleStart()
+    {
+        return this.validNamePointLowerCaseArticleStart;
+    }
+
+    public Atlas invalidNamePointLowerCaseArticleStart()
+    {
+        return this.invalidNamePointLowerCaseArticleStart;
     }
 
     public Atlas invalidNamePointEn()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTestRule.java
@@ -1,0 +1,5 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+public class MixedCaseNameCheckTestRule
+{
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTestRule.java
@@ -165,6 +165,12 @@ public class MixedCaseNameCheckTestRule extends CoreTestRule
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=Test (20kV) Test" }) })
+    private Atlas validNamePointMixedCaseUnitAtlas;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name:en=tEst TeSt" }) })
     private Atlas invalidNamePointEnAtlas;
 
@@ -317,6 +323,11 @@ public class MixedCaseNameCheckTestRule extends CoreTestRule
     public Atlas invalidNamePointLowerCaseArticleStartAtlas()
     {
         return this.invalidNamePointLowerCaseArticleStartAtlas;
+    }
+
+    public Atlas validNamePointMixedCaseUnitAtlas()
+    {
+        return this.validNamePointMixedCaseUnitAtlas;
     }
 
     public Atlas invalidNamePointEnAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTestRule.java
@@ -111,6 +111,18 @@ public class MixedCaseNameCheckTestRule extends CoreTestRule
     @TestAtlas(
             // points
             points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=SCOTT's" }) })
+    private Atlas validNamePointCapsApostrophe;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=SCOTTs'" }) })
+    private Atlas validNamePointCapsLowerApostrophe;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
                     "name=Scott'S" }) })
     private Atlas invalidNamePointApostrophe;
 
@@ -260,6 +272,16 @@ public class MixedCaseNameCheckTestRule extends CoreTestRule
     public Atlas validNamePointApostropheAllCaps()
     {
         return this.validNamePointApostropheAllCaps;
+    }
+
+    public Atlas validNamePointCapsApostrophe()
+    {
+        return this.validNamePointCapsApostrophe;
+    }
+
+    public Atlas validNamePointCapsLowerApostrophe()
+    {
+        return this.validNamePointCapsLowerApostrophe;
     }
 
     public Atlas invalidNamePointApostrophe()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTestRule.java
@@ -1,5 +1,290 @@
 package org.openstreetmap.atlas.checks.validation.tag;
 
-public class MixedCaseNameCheckTestRule
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Line;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
+
+/**
+ * Tests for {@link MixedCaseNameCheck}
+ *
+ * @author bbreithaupt
+ */
+public class MixedCaseNameCheckTestRule extends CoreTestRule
 {
+    private static final String TEST_1 = "47.2136626201459,-122.443275382856";
+    private static final String TEST_2 = "47.2138327316739,-122.44258668766";
+    private static final String TEST_3 = "47.2136626201459,-122.441897992465";
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=tEst TeSt" }) })
+    private Atlas invalidNamePoint;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=tEst TeSt" }) })
+    private Atlas invalidNameNode;
+
+    @TestAtlas(
+            // Lines
+            lines = { @Line(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                    @Loc(value = TEST_3) }, tags = { "iso_country_code=USA", "name=tEst TeSt" }) })
+    private Atlas invalidNameLine;
+
+    @TestAtlas(
+            // Areas
+            areas = { @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                    @Loc(value = TEST_3) }, tags = { "iso_country_code=USA", "name=tEst TeSt" }) })
+    private Atlas invalidNameArea;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_3)) },
+            // edges
+            edges = { @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                    @Loc(value = TEST_3) }, tags = { "iso_country_code=USA", "name=tEst TeSt" }) })
+    private Atlas invalidNameEdge;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=tEst" }) })
+    private Atlas invalidNamePointOneWord;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=Test-Test" }) })
+    private Atlas validNamePointHyphen;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=Test-TesT" }) })
+    private Atlas invalidNamePointHyphen;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=McMan" }) })
+    private Atlas validNamePointAffix;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=McMaN" }) })
+    private Atlas invalidNamePointAffix;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=O'Flanagan" }) })
+    private Atlas validNamePointApostrophe;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=Scott's" }) })
+    private Atlas validNamePointApostropheLower;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=SCOTT'S" }) })
+    private Atlas validNamePointApostropheAllCaps;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=Scott'S" }) })
+    private Atlas invalidNamePointApostrophe;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=TEST" }) })
+    private Atlas validNamePointAllCaps;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=test" }) })
+    private Atlas validNamePointNoCaps;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name=Test of Test" }) })
+    private Atlas validNamePointLowerCaseWord;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=USA",
+                    "name:en=tEst TeSt" }) })
+    private Atlas invalidNamePointEn;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=GRC",
+                    "name=τΕστ ΤεΣτ" }) })
+    private Atlas invalidNamePointGreek;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=GRC",
+                    "name=Τεστ Τεστ" }) })
+    private Atlas validNamePointGreek;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=GRC",
+                    "name:el=τΕστ ΤεΣτ" }) })
+    private Atlas invalidNamePointGreekEl;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=GRC",
+                    "name:el=Τεστ Τεστ" }) })
+    private Atlas validNamePointGreekEl;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=CHN",
+                    "name:en=tEst TeSt", "name=Test of Test" }) })
+    private Atlas invalidNamePointChn;
+
+    @TestAtlas(
+            // points
+            points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "iso_country_code=CHN",
+                    "name:en=Test of Test", "name=tEst TeSt" }) })
+    private Atlas validNamePointChn;
+
+    public Atlas invalidNamePoint()
+    {
+        return this.invalidNamePoint;
+    }
+
+    public Atlas invalidNameNode()
+    {
+        return this.invalidNameNode;
+    }
+
+    public Atlas invalidNameLine()
+    {
+        return this.invalidNameLine;
+    }
+
+    public Atlas invalidNameArea()
+    {
+        return this.invalidNameArea;
+    }
+
+    public Atlas invalidNameEdge()
+    {
+        return this.invalidNameEdge;
+    }
+
+    public Atlas invalidNamePointOneWord()
+    {
+        return this.invalidNamePointOneWord;
+    }
+
+    public Atlas validNamePointHyphen()
+    {
+        return this.validNamePointHyphen;
+    }
+
+    public Atlas invalidNamePointHyphen()
+    {
+        return this.invalidNamePointHyphen;
+    }
+
+    public Atlas validNamePointAffix()
+    {
+        return this.validNamePointAffix;
+    }
+
+    public Atlas invalidNamePointAffix()
+    {
+        return this.invalidNamePointAffix;
+    }
+
+    public Atlas validNamePointApostrophe()
+    {
+        return this.validNamePointApostrophe;
+    }
+
+    public Atlas validNamePointApostropheLower()
+    {
+        return this.validNamePointApostropheLower;
+    }
+
+    public Atlas validNamePointApostropheAllCaps()
+    {
+        return this.validNamePointApostropheAllCaps;
+    }
+
+    public Atlas invalidNamePointApostrophe()
+    {
+        return this.invalidNamePointApostrophe;
+    }
+
+    public Atlas validNamePointAllCaps()
+    {
+        return this.validNamePointAllCaps;
+    }
+
+    public Atlas validNamePointNoCaps()
+    {
+        return this.validNamePointNoCaps;
+    }
+
+    public Atlas validNamePointLowerCaseWord()
+    {
+        return this.validNamePointLowerCaseWord;
+    }
+
+    public Atlas invalidNamePointEn()
+    {
+        return this.invalidNamePointEn;
+    }
+
+    public Atlas invalidNamePointGreek()
+    {
+        return this.invalidNamePointGreek;
+    }
+
+    public Atlas validNamePointGreek()
+    {
+        return this.validNamePointGreek;
+    }
+
+    public Atlas invalidNamePointGreekEl()
+    {
+        return this.invalidNamePointGreekEl;
+    }
+
+    public Atlas validNamePointGreekEl()
+    {
+        return this.validNamePointGreekEl;
+    }
+
+    public Atlas invalidNamePointChn()
+    {
+        return this.invalidNamePointChn;
+    }
+
+    public Atlas validNamePointChn()
+    {
+        return this.validNamePointChn;
+    }
 }


### PR DESCRIPTION
This check flags objects with name tags that improperly use mixed cases.

Proper case use is defined by set standards and configurable exceptions. 

The standards are as follows:

* Words must start with a capital unless:
    * The first letter is preceded by a number
    * All the words in the name are lower case
* All other letters must be lower case unless: 
    * They follow an apostrophe and, they are not the last letter of the word
    * The entire word is uppercase, except the last letter if it follows or is followed by an apostrophe

The standards are broken by the following configurable exceptions (with default values):

* Articles that are capitalised only if they are the first word:
    * a, an, the
* Prepositions that do not need to start with a capital:
    * and, from, to, of, by, upon, on, off, at, as, into, like, near, onto, per, till, up, via, with, for, in
* Name affixes that may be followed by a capital:
    * Mc, Mac, Mck, Mhic, Mic
* Mixed case units of measurement that are valid after a number:
    * kV
    
These configurables allow this check to be adapted to test different languages.  
OSM uses the `name` tag for the name in a locations primary language, and `name:[ISOcode]` for other languages.
This check uses two configurable to control what languages are checked.

The first is a list of ISO codes for countries that should have there `name` tag checked. It has default values of:

* AIA, ATG, AUS, BHS, BRB, BLZ, BMU, BWA, VGB, CMR, CAN, CYM, DMA, FJI, GMB, GHA, GIB, GRD, GUY, IRL, JAM, KEN, LSO, MWI, MLT, MUS, MSR, NAM, NZL, NGA, PNG, SYC, SLE, SGP, SLB, ZAF, SWZ, TZA, TON, TTO, TCA, UGA, GBR, USA, VUT, ZMB, ZWE

The second is a list of `name:[ISOcode]` tags to check. Default values are:

* name:en

A final configurable is a list of characters that names are split by to for words. Its default values are: 

* SPACE, \-, /, &, @, –

**OSM Example:**
1. Way [id:4780932622](https://www.openstreetmap.org/node/4780932622) has the name `NZ Convenience store`. It is flagged because the S in store should be capitalized. 
2. Way [id:463905525](https://www.openstreetmap.org/way/463905525) has the name:en of `ATM drive through`. This is flagged because drive and through should be capitalized. ATM is fine because it is an all upper case word. 
