### PR TITLE
One Member Relation Enhancement Review

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
@@ -86,10 +86,12 @@ public class OneMemberRelationCheck extends BaseCheck
      */
     private Set<AtlasObject> getRelationMembers(final Relation relation)
     {
+        // Gather a set of the relation's members
         final Set<AtlasObject> relationMembers = relation.members().stream()
                 .map(RelationMember::getEntity).collect(Collectors.toSet());
         relationMembers.forEach(member ->
         {
+            // Recursively replace sub relations with their members
             if (member instanceof Relation)
             {
                 relationMembers.addAll(getRelationMembers((Relation) member));

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
@@ -22,7 +22,8 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  */
 public class OneMemberRelationCheck extends BaseCheck
 {
-    public static final String OMR_INSTRUCTIONS = "This relation, {0,number,#}, contains only one member.";
+    public static final String OMR_INSTRUCTIONS = "This relation, {0,number,#}, contains only "
+            + "one member.";
 
     public static final String MULTIPOLYGON_OMR_INSTRUCTIONS = "This relation, {0,number,#}, contains only "
             + "one member. Multi-polygon relations need multiple polygons.";

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
@@ -77,6 +77,13 @@ public class OneMemberRelationCheck extends BaseCheck
         return Optional.empty();
     }
 
+    /**
+     * Recursively gets the members of relations.
+     *
+     * @param relation
+     *            {@link Relation} to get the members of
+     * @return A {@link Set} of the relations members as {@link AtlasObject}s
+     */
     private Set<AtlasObject> getRelationMembers(final Relation relation)
     {
         final Set<AtlasObject> relationMembers = relation.members().stream()

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
@@ -3,11 +3,13 @@ package org.openstreetmap.atlas.checks.validation.relations;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMemberList;
@@ -20,14 +22,15 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  */
 public class OneMemberRelationCheck extends BaseCheck
 {
-    public static final String OMR_INSTRUCTIONS = "This relation, {0,number,#}, contains only "
-            + "one member.";
+    public static final String OMR_INSTRUCTIONS = "This relation, {0,number,#}, contains only one member.";
 
     public static final String MULTIPOLYGON_OMR_INSTRUCTIONS = "This relation, {0,number,#}, contains only "
             + "one member. Multi-polygon relations need multiple polygons.";
 
+    public static final String MEMBER_RELATION_INSTRUCTIONS = "This relation, {0,number,#}, contains only relation {1,number,#}.";
+
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(OMR_INSTRUCTIONS,
-            MULTIPOLYGON_OMR_INSTRUCTIONS);
+            MULTIPOLYGON_OMR_INSTRUCTIONS, MEMBER_RELATION_INSTRUCTIONS);
 
     @Override
     protected List<String> getFallbackInstructions()
@@ -55,20 +58,36 @@ public class OneMemberRelationCheck extends BaseCheck
         // If the number of members in the relation is 1
         if (members.size() == 1)
         {
+            if (members.get(0).getEntity().getType().equals(ItemType.RELATION))
+            {
+                return Optional.of(createFlag(getRelationMembers((Relation) object),
+                        this.getLocalizedInstruction(2, relation.getOsmIdentifier(),
+                                members.get(0).getEntity().getOsmIdentifier())));
+            }
             // If the relation is a multi-polygon,
             if (relation.isMultiPolygon())
             {
-                return Optional.of(createFlag(
-                        relation.members().stream().map(RelationMember::getEntity)
-                                .collect(Collectors.toSet()),
+                return Optional.of(createFlag(getRelationMembers((Relation) object),
                         this.getLocalizedInstruction(1, relation.getOsmIdentifier())));
             }
-
-            return Optional.of(createFlag(
-                    relation.members().stream().map(RelationMember::getEntity)
-                            .collect(Collectors.toSet()),
+            return Optional.of(createFlag(getRelationMembers((Relation) object),
                     this.getLocalizedInstruction(0, relation.getOsmIdentifier())));
         }
         return Optional.empty();
+    }
+
+    private Set<AtlasObject> getRelationMembers(final Relation relation)
+    {
+        final Set<AtlasObject> relationMembers = relation.members().stream()
+                .map(RelationMember::getEntity).collect(Collectors.toSet());
+        relationMembers.forEach(member ->
+        {
+            if (member instanceof Relation)
+            {
+                relationMembers.addAll(getRelationMembers((Relation) member));
+                relationMembers.remove(member);
+            }
+        });
+        return relationMembers;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
@@ -58,7 +58,7 @@ public class OneMemberRelationCheckTest
     }
 
     @Test
-    public void oneMemberRelationRelationTest()
+    public void testOneMemberRelationRelationTest()
     {
         this.verifier.actual(this.setup.oneMemberRelationRelationAtlas(), check);
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
@@ -58,7 +58,7 @@ public class OneMemberRelationCheckTest
     }
 
     @Test
-    public void testOneMemberRelationRelationTest()
+    public void testOneMemberRelationRelation()
     {
         this.verifier.actual(this.setup.oneMemberRelationRelationAtlas(), check);
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
@@ -57,4 +57,12 @@ public class OneMemberRelationCheckTest
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
+    @Test
+    public void oneMemberRelationRelationTest()
+    {
+        this.verifier.actual(this.setup.oneMemberRelationRelationAtlas(), check);
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(flag.getFlaggedObjects().size(), 3));
+    }
+
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTestRule.java
@@ -102,6 +102,31 @@ public class OneMemberRelationCheckTestRule extends CoreTestRule
                             "restriction=no_u_turn", "type=multipolygon" }) })
     private Atlas validRelationMultipolygon;
 
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2", coordinates = @Loc(value = TWO)),
+                    @Node(id = "3", coordinates = @Loc(value = THREE)) },
+            // edges
+            edges = {
+                    @Edge(id = "12", coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO) }, tags = { "highway=road" }),
+                    @Edge(id = "23", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }, tags = { "highway=road" }),
+                    @Edge(id = "31", coordinates = { @Loc(value = THREE),
+                            @Loc(value = ONE) }, tags = { "highway=road" }) },
+            // relations
+            relations = {
+                    @Relation(id = "123", members = {
+                            @Member(id = "12", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_FROM),
+                            @Member(id = "2", type = "node", role = RelationTypeTag.RESTRICTION_ROLE_VIA),
+                            @Member(id = "23", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_TO) }, tags = {
+                                    "restriction=no_u_turn" }),
+                    @Relation(id = "1231", members = {
+                            @Member(id = "123", type = "relation", role = RelationTypeTag.RESTRICTION_ROLE_FROM) }, tags = {
+                                    "restriction=no_u_turn" }) })
+    private Atlas oneMemberRelationRelationAtlas;
+
     public Atlas getValidRelation()
     {
         return this.validRelation;
@@ -125,5 +150,10 @@ public class OneMemberRelationCheckTestRule extends CoreTestRule
     public Atlas getValidRelationMultipolygon()
     {
         return this.validRelationMultipolygon;
+    }
+
+    public Atlas oneMemberRelationRelationAtlas()
+    {
+        return this.oneMemberRelationRelationAtlas;
     }
 }


### PR DESCRIPTION
This enhancement is to fix an issue where flags with empty geometries were being created. This was occurring when a relation with another relation as its only member was flagged. 

Now in these situations the geometry of the nested relations is recursively gathered, to show what the relation represents, and the situation is noted in the instruction. 