### PR TITLE
Unusual Layer Tag Bug Fix & Enhancement

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -360,6 +360,14 @@
       "tags":"highway"
     }
   },
+  "UnusualLayerTagsCheck": {
+    "challenge": {
+      "description": "Tunnels (negative), junctions (zero) and bridges (zero or positive) should have meaningful layer tags attached to them. A missing layer tag implies layer value 0. If there is an explicit layer tag, then it must be between -5 and 5.",
+      "blurb": "Verify unusual layer tags.",
+      "instruction": "Open your favorite editor, check the instruction for the task and then modify the tag that is considered unusual or possibly invalid.",
+      "difficulty": "EASY"
+    }
+  },
   "WaterbodyAndIslandSizeCheck": {
     "surface":{
       "waterbody.minimum.meters": 10.0,

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheck.java
@@ -30,22 +30,22 @@ public class UnusualLayerTagsCheck extends BaseCheck<Long>
     public static final String INVALID_LAYER_INSTRUCTION = String.format(
             "A layer tag must have a value in [%d, %d] and 0 should not be used explicitly.",
             LayerTag.getMinValue(), LayerTag.getMaxValue());
-    public static final String JUNCTION_INSTRUCTION = "Junction edges with valid layer value "
+    public static final String JUNCTION_INSTRUCTION = "Junctions with valid layer values "
             + "must include bridge or tunnel tags";
     private static final Predicate<Taggable> ALLOWED_TAGS;
     private static final long BRIDGE_LAYER_TAG_MAX_VALUE = LayerTag.getMaxValue();
     // Constants for bridge checks
     private static final long BRIDGE_LAYER_TAG_MIN_VALUE = 1;
     public static final String BRIDGE_INSTRUCTION = String.format(
-            "Bridge edges must have a layer tag set to a value in [%d, %d].",
-            BRIDGE_LAYER_TAG_MIN_VALUE, BRIDGE_LAYER_TAG_MAX_VALUE);
+            "Bridges must have a layer tag set to a value in [%d, %d].", BRIDGE_LAYER_TAG_MIN_VALUE,
+            BRIDGE_LAYER_TAG_MAX_VALUE);
     private static final int THREE = 3;
     private static final long TUNNEL_LAYER_TAG_MAX_VALUE = -1;
     // Constants for tunnel checks
     private static final long TUNNEL_LAYER_TAG_MIN_VALUE = LayerTag.getMinValue();
     public static final String TUNNEL_INSTRUCTION = String.format(
-            "Tunnel edges must have layer tag set to a value in [%d, %d].",
-            TUNNEL_LAYER_TAG_MIN_VALUE, TUNNEL_LAYER_TAG_MAX_VALUE);
+            "Tunnels must have layer tags set to a value in [%d, %d].", TUNNEL_LAYER_TAG_MIN_VALUE,
+            TUNNEL_LAYER_TAG_MAX_VALUE);
     public static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(TUNNEL_INSTRUCTION,
             JUNCTION_INSTRUCTION, BRIDGE_INSTRUCTION, INVALID_LAYER_INSTRUCTION);
     // tunnel=building_passage should be excluded from eligible candidates

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheck.java
@@ -22,7 +22,7 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  * Checks {@link Edge}'s {@link LayerTag} and flags it if the value is unusual. Also see
  * http://wiki.openstreetmap.org/wiki/Key:layer
  *
- * @author mkalender
+ * @author mkalender, bbreithaupt
  */
 public class UnusualLayerTagsCheck extends BaseCheck<Long>
 {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheck.java
@@ -37,7 +37,7 @@ public class UnusualLayerTagsCheck extends BaseCheck<Long>
     // Constants for bridge checks
     private static final long BRIDGE_LAYER_TAG_MIN_VALUE = 1;
     public static final String BRIDGE_INSTRUCTION = String.format(
-            "Bridge edges must have no layer tag or a layer tag set to a value in [%d, %d].",
+            "Bridge edges must have a layer tag set to a value in [%d, %d].",
             BRIDGE_LAYER_TAG_MIN_VALUE, BRIDGE_LAYER_TAG_MAX_VALUE);
     private static final int THREE = 3;
     private static final long TUNNEL_LAYER_TAG_MAX_VALUE = -1;
@@ -55,13 +55,11 @@ public class UnusualLayerTagsCheck extends BaseCheck<Long>
     private static final long serialVersionUID = 7040472721500502360L;
 
     /**
-     * Initializes a predicate to limit check for tunnels, junctions, bridges and edges with layer
-     * tag values
+     * Initializes a predicate to limit check for tunnels, bridges and edges with layer tag values
      */
     static
     {
-        ALLOWED_TAGS = Validators.hasValuesFor(JunctionTag.class)
-                .or(Validators.hasValuesFor(BridgeTag.class))
+        ALLOWED_TAGS = Validators.hasValuesFor(BridgeTag.class)
                 .or(Validators.hasValuesFor(LayerTag.class)).or(ELIGIBLE_TUNNEL_TAGS);
     }
 
@@ -78,7 +76,7 @@ public class UnusualLayerTagsCheck extends BaseCheck<Long>
 
     /**
      * Validate if given {@link AtlasObject} is actually an {@link Edge} and make sure the edge has
-     * one of the following tags: tunnel, junction, bridge, layer
+     * one of the following tags: tunnel, bridge, layer
      */
     @Override
     public boolean validCheckForObject(final AtlasObject object)

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheckTest.java
@@ -116,6 +116,18 @@ public class UnusualLayerTagsCheckTest
     }
 
     @Test
+    public void testMinusInfinityLayerTagJunctionEdge()
+    {
+        this.verifier.actual(this.setup.minusInfinityLayerTagJunctionEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(flag.getInstructions()
+                    .contains(UnusualLayerTagsCheck.INVALID_LAYER_INSTRUCTION));
+        });
+    }
+
+    @Test
     public void testMinusInfinityTunnelLayerTagEdge()
     {
         this.verifier.actual(this.setup.minusInfinityLayerTagTunnelEdgeAtlas(), check);
@@ -144,6 +156,18 @@ public class UnusualLayerTagsCheckTest
     {
         this.verifier.actual(this.setup.minusOneLayerTagEdgeAtlas(), check);
         this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testMinusOneLayerTagJunctionEdge()
+    {
+        this.verifier.actual(this.setup.minusOneLayerTagJunctionEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.JUNCTION_INSTRUCTION));
+        });
     }
 
     @Test
@@ -299,6 +323,18 @@ public class UnusualLayerTagsCheckTest
     }
 
     @Test
+    public void testPlusInfinityLayerTagJunctionEdge()
+    {
+        this.verifier.actual(this.setup.plusInfinityLayerTagJunctionEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(flag.getInstructions()
+                    .contains(UnusualLayerTagsCheck.INVALID_LAYER_INSTRUCTION));
+        });
+    }
+
+    @Test
     public void testPlusInfinityTunnelLayerTagEdge()
     {
         this.verifier.actual(this.setup.plusInfinityLayerTagTunnelEdgeAtlas(), check);
@@ -322,6 +358,18 @@ public class UnusualLayerTagsCheckTest
     {
         this.verifier.actual(this.setup.plusOneLayerTagEdgeAtlas(), check);
         this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testPlusOneLayerTagJunctionEdge()
+    {
+        this.verifier.actual(this.setup.plusOneLayerTagJunctionEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.JUNCTION_INSTRUCTION));
+        });
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheckTest.java
@@ -183,7 +183,7 @@ public class UnusualLayerTagsCheckTest
     public void testMissingBridgeLayerTagEdge()
     {
         this.verifier.actual(this.setup.missingLayerTagBridgeEdgeAtlas(), check);
-        this.verifier.verifyEmpty();
+        this.verifier.verifyNotEmpty();
     }
 
     @Test
@@ -228,10 +228,11 @@ public class UnusualLayerTagsCheckTest
     public void testNullJunctionLayerTagEdge()
     {
         this.verifier.actual(this.setup.nullLayerTagJunctionEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
         this.verifier.verify(flag ->
         {
-            Assert.assertTrue(
-                    flag.getInstructions().contains(UnusualLayerTagsCheck.JUNCTION_INSTRUCTION));
+            Assert.assertTrue(flag.getInstructions()
+                    .contains(UnusualLayerTagsCheck.INVALID_LAYER_INSTRUCTION));
         });
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheckTest.java
@@ -9,7 +9,7 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
 /**
  * {@link UnusualLayerTagsCheck} unit test
  *
- * @author mkalender
+ * @author mkalender, bbreithaupt
  */
 public class UnusualLayerTagsCheckTest
 {

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheckTestRule.java
@@ -10,7 +10,7 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
 /**
  * {@link UnusualLayerTagsCheck} test data
  *
- * @author mkalender
+ * @author mkalender, bbreithaupt
  */
 public class UnusualLayerTagsCheckTestRule extends CoreTestRule
 {

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheckTestRule.java
@@ -42,20 +42,21 @@ public class UnusualLayerTagsCheckTestRule extends CoreTestRule
     private Atlas invalidLayerTagTunnelEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
-            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
-                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }) })
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
+                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "highway=secondary" }) })
     private Atlas missingLayerTagEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
-            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
-                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
-                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "bridge=yes" }) })
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "bridge=yes", "highway=secondary" }) })
     private Atlas missingLayerTagBridgeEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
-            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
-                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
-                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "junction=roundabout" }) })
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "junction=roundabout", "highway=secondary" }) })
     private Atlas missingLayerTagJunctionEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
@@ -83,7 +84,7 @@ public class UnusualLayerTagsCheckTestRule extends CoreTestRule
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
             @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
                     @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
-                            "layer=null", "junction=roundabout" }) })
+                            "layer=null", "junction=roundabout", "highway=secondary" }) })
     private Atlas nullLayerTagJunctionEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
@@ -142,9 +143,9 @@ public class UnusualLayerTagsCheckTestRule extends CoreTestRule
     private Atlas minusInfinityLayerTagEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
-            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
-                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
-                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=-1" }) })
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=-1", "highway=secondary" }) })
     private Atlas minusOneLayerTagEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
@@ -154,9 +155,9 @@ public class UnusualLayerTagsCheckTestRule extends CoreTestRule
     private Atlas zeroLayerTagEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
-            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
-                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
-                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=1" }) })
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=1",
+                            "highway=secondary" }) })
     private Atlas plusOneLayerTagEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
@@ -169,25 +170,25 @@ public class UnusualLayerTagsCheckTestRule extends CoreTestRule
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
             @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
                     @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
-                            "layer=-2147483648", "junction=roundabout" }) })
+                            "layer=-2147483648", "junction=roundabout", "highway=secondary" }) })
     private Atlas minusInfinityLayerTagJunctionEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
             @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
                     @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
-                            "layer=-1", "junction=roundabout" }) })
+                            "layer=-1", "junction=roundabout", "highway=secondary" }) })
     private Atlas minusOneLayerTagJunctionEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
             @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
                     @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=1",
-                            "junction=roundabout" }) })
+                            "junction=roundabout", "highway=secondary" }) })
     private Atlas plusOneLayerTagJunctionEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
             @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
                     @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
-                            "layer=2147483647", "junction=roundabout" }) })
+                            "layer=2147483647", "junction=roundabout", "highway=secondary" }) })
     private Atlas plusInfinityLayerTagJunctionEdgeAtlas;
 
     // More bridge atlases
@@ -204,33 +205,33 @@ public class UnusualLayerTagsCheckTestRule extends CoreTestRule
     private Atlas minusOneLayerTagBridgeEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
-            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
-                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
-                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=1", "bridge=yes" }) })
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=1",
+                            "bridge=yes", "highway=secondary" }) })
     private Atlas plusOneLayerTagBridgeEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
-            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
-                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
-                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=2", "bridge=yes" }) })
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=2",
+                            "bridge=yes", "highway=secondary" }) })
     private Atlas plusTwoLayerTagBridgeEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
-            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
-                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
-                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=3", "bridge=yes" }) })
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=3",
+                            "bridge=yes", "highway=secondary" }) })
     private Atlas plusThreeLayerTagBridgeEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
-            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
-                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
-                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=4", "bridge=yes" }) })
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=4",
+                            "bridge=yes", "highway=secondary" }) })
     private Atlas plusFourLayerTagBridgeEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
-            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
-                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
-                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=5", "bridge=yes" }) })
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=5",
+                            "bridge=yes", "highway=secondary" }) })
     private Atlas plusFiveLayerTagBridgeEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
@@ -259,33 +260,33 @@ public class UnusualLayerTagsCheckTestRule extends CoreTestRule
     private Atlas minusSixLayerTagTunnelEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
-            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
-                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
-                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=-5", "tunnel=yes" }) })
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=-5", "tunnel=yes", "highway=secondary" }) })
     private Atlas minusFiveLayerTagTunnelEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
-            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
-                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
-                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=-4", "tunnel=yes" }) })
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=-4", "tunnel=yes", "highway=secondary" }) })
     private Atlas minusFourLayerTagTunnelEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
-            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
-                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
-                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=-3", "tunnel=yes" }) })
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=-3", "tunnel=yes", "highway=secondary" }) })
     private Atlas minusThreeLayerTagTunnelEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
-            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
-                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
-                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=-2", "tunnel=yes" }) })
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=-2", "tunnel=yes", "highway=secondary" }) })
     private Atlas minusTwoLayerTagTunnelEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
-            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
-                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
-                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=-1", "tunnel=yes" }) })
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=-1", "tunnel=yes", "highway=secondary" }) })
     private Atlas minusOneLayerTagTunnelEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),


### PR DESCRIPTION
### Description:

The main change in this PR stemmed from a bug created by a change of a LayerTag method (see https://github.com/osmlab/atlas-checks/issues/77). To fix this issue the check has been changed to no longer check all Edges with junction tags. 
This bug should have been caught by the unit tests, but were missed due to a lack of car navigable highway tags.  Unit test have been updated to address this. 

Also included in this PR are a change of the instructions, and adding the check to the configuration file. The instruction change just removes an unnecessary mention of edges. 

### Potential Impact:

Remove a large number of false positives.

### Unit Test Approach:

Unit tests were updated so that all edges have car navigable highway tags. This prevents them from being filtered out in `validCheckForObject`.
A unit test was updated to check for the correct instruction. 
4 unit tests were added to use 4 existing, unused Test Atlases for junctions. 

### Test Results:

Testing showed false positive rates dropped back to expected levels after the fix. 

