### PR TITLE
EdgeCrossingEdgeCheck Bug Fix & Enhancements

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -86,6 +86,7 @@
     }
   },
   "EdgeCrossingEdgeCheck": {
+    "minimum.highway.type": "service",
     "challenge": {
       "description": "Tasks contain ways that do not have shared nodes but cross each other.",
       "blurb": "Crossing Ways",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
@@ -185,9 +185,10 @@ public class EdgeCrossingEdgeCheck extends BaseCheck
             final Optional<HighwayTag> highway = HighwayTag.highwayTag(object);
             if (highway.isPresent())
             {
-                return HighwayTag.isCarNavigableHighway(highway.get())
-                        && !HighwayTag.CROSSING.equals(highway.get())
-                        && highway.get().isMoreImportantThanOrEqualTo(this.minimumHighwayType);
+                final HighwayTag highwayTag = highway.get();
+                return HighwayTag.isCarNavigableHighway(highwayTag)
+                        && !HighwayTag.CROSSING.equals(highwayTag)
+                        && highwayTag.isMoreImportantThanOrEqualTo(this.minimumHighwayType);
             }
         }
         return false;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
@@ -1,15 +1,16 @@
 package org.openstreetmap.atlas.checks.validation.intersections;
 
+import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.LinkedList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 
 import org.openstreetmap.atlas.checks.atlas.predicates.TagPredicates;
 import org.openstreetmap.atlas.checks.atlas.predicates.TypePredicates;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
-import org.openstreetmap.atlas.checks.constants.CommonConstants;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
@@ -20,6 +21,7 @@ import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.LayerTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
@@ -29,7 +31,7 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  *
  * @author mkalender, gpogulsky, bbreithaupt
  */
-public class EdgeCrossingEdgeCheck extends BaseCheck<String>
+public class EdgeCrossingEdgeCheck extends BaseCheck
 {
     private static final String INSTRUCTION_FORMAT = "The road with id {0,number,#} has invalid crossings."
             + " If two roads are crossing each other, then they should have nodes at intersection"
@@ -71,22 +73,12 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<String>
                         && !edgeLayer.get().equals(crossingEdgeLayer.get());
     }
 
-    private static String generateAtlasObjectPairIdentifier(final AtlasObject thisObject,
-            final AtlasObject thatObject)
-    {
-        if (thisObject.getIdentifier() < thatObject.getIdentifier())
-        {
-            return thisObject.getIdentifier() + CommonConstants.DASH + thatObject.getIdentifier();
-        }
-
-        return thatObject.getIdentifier() + CommonConstants.DASH + thisObject.getIdentifier();
-    }
-
     public EdgeCrossingEdgeCheck(final Configuration configuration)
     {
         super(configuration);
-        this.minimumHighwayType = configurationValue(configuration, "minimum.highway.type",
-                MINIMUM_HIGHWAY_DEFAULT, str -> Enum.valueOf(HighwayTag.class, str.toUpperCase()));
+        this.minimumHighwayType = (HighwayTag) configurationValue(configuration,
+                "minimum.highway.type", MINIMUM_HIGHWAY_DEFAULT,
+                str -> Enum.valueOf(HighwayTag.class, ((String) str).toUpperCase()));
     }
 
     @Override
@@ -98,67 +90,72 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<String>
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
-        // Prepare the edge being tested for checks
-        final Edge edge = (Edge) object;
-        final PolyLine edgeAsPolyLine = edge.asPolyLine();
-        final Rectangle edgeBounds = edge.bounds();
-        final Optional<Long> edgeLayer = Validators.hasValuesFor(edge, LayerTag.class)
-                ? LayerTag.getTaggedValue(edge) : Optional.of(0L);
+        final Set<Edge> invalidEdges = new HashSet<>();
+        final Queue<Edge> toCheck = new ArrayDeque<>();
+        invalidEdges.add((Edge) object);
+        toCheck.add((Edge) object);
 
-        // Retrieve crossing edges
-        final Atlas atlas = object.getAtlas();
-        final Iterable<Edge> crossingEdges = atlas.edgesIntersecting(edgeBounds,
-                // filter out the same edge, non-valid crossing edges and already flagged ones
-                crossingEdge -> edge.getIdentifier() != crossingEdge.getIdentifier()
-                        && isValidCrossingEdge(crossingEdge)
-                        && !this.isFlagged(generateAtlasObjectPairIdentifier(edge, crossingEdge)));
-
-        List<Edge> invalidEdges = null;
-
-        // Go through crossing items and collect invalid crossings
-        // NOTE: Due to way sectioning same OSM way could be marked multiple times here. However,
-        // MapRoulette will display way-sectioned edges in case there is an invalid crossing.
-        // Therefore, if an OSM way crosses another OSM way multiple times in separate edges, then
-        // each edge will be marked explicitly.
-        for (final Edge crossingEdge : crossingEdges)
+        // Use BFS to gather all connected invalid crossings, to avoid flagging edges more than once
+        while (!toCheck.isEmpty())
         {
-            final PolyLine crossingEdgeAsPolyLine = crossingEdge.asPolyLine();
-            final Optional<Long> crossingEdgeLayer = Validators.hasValuesFor(crossingEdge,
-                    LayerTag.class) ? LayerTag.getTaggedValue(crossingEdge) : Optional.of(0L);
-            final Set<Location> intersections = edgeAsPolyLine
-                    .intersections(crossingEdgeAsPolyLine);
+            final Edge edge = toCheck.poll();
 
-            // Check whether crossing edge can actually cross
-            for (final Location intersection : intersections)
+            // Prepare the edge being tested for checks
+            final PolyLine edgeAsPolyLine = edge.asPolyLine();
+            final Rectangle edgeBounds = edge.bounds();
+            // If layer tag is present use its value, else use the OSM default
+            final Optional<Long> edgeLayer = Validators.hasValuesFor(edge, LayerTag.class)
+                    ? LayerTag.getTaggedValue(edge) : Optional.of(0L);
+
+            // Retrieve crossing edges
+            final Atlas atlas = object.getAtlas();
+            final List<Edge> crossingEdges = Iterables.asList(atlas.edgesIntersecting(edgeBounds,
+                    // filter out the same edge, non-valid crossing edges and already flagged ones
+                    crossingEdge -> edge.getIdentifier() != crossingEdge.getIdentifier()
+                            && isValidCrossingEdge(crossingEdge)
+                            && !invalidEdges.contains(crossingEdge)));
+
+            // Go through crossing items and collect invalid crossings
+            // NOTE: Due to way sectioning same OSM way could be marked multiple times here.
+            // However,
+            // MapRoulette will display way-sectioned edges in case there is an invalid crossing.
+            // Therefore, if an OSM way crosses another OSM way multiple times in separate edges,
+            // then
+            // each edge will be marked explicitly.
+            for (final Edge crossingEdge : crossingEdges)
             {
-                // Add this set to flagged pairs to skip it next time
-                this.markAsFlagged(generateAtlasObjectPairIdentifier(edge, crossingEdge));
+                final PolyLine crossingEdgeAsPolyLine = crossingEdge.asPolyLine();
+                final Optional<Long> crossingEdgeLayer = Validators.hasValuesFor(crossingEdge,
+                        LayerTag.class) ? LayerTag.getTaggedValue(crossingEdge) : Optional.of(0L);
+                final Set<Location> intersections = edgeAsPolyLine
+                        .intersections(crossingEdgeAsPolyLine);
 
-                // Check if crossing is valid or not
-                if (canCross(edgeAsPolyLine, edgeLayer, crossingEdgeAsPolyLine, crossingEdgeLayer,
-                        intersection))
+                // Check whether crossing edge can actually cross
+                for (final Location intersection : intersections)
                 {
-                    continue;
-                }
+                    // Check if crossing is valid or not
+                    if (canCross(edgeAsPolyLine, edgeLayer, crossingEdgeAsPolyLine,
+                            crossingEdgeLayer, intersection))
+                    {
+                        continue;
+                    }
 
-                if (invalidEdges == null)
-                {
-                    // Normally we expect 1 or 2 edges in the list
-                    invalidEdges = new LinkedList<>();
+                    invalidEdges.add(crossingEdge);
+                    toCheck.add(crossingEdge);
                 }
-
-                invalidEdges.add(crossingEdge);
             }
         }
 
-        if (invalidEdges != null)
+        if (invalidEdges.size() > 1)
         {
             final CheckFlag newFlag = new CheckFlag(getTaskIdentifier(object));
+            this.markAsFlagged(object.getIdentifier());
             newFlag.addObject(object);
             newFlag.addInstruction(this.getLocalizedInstruction(0, object.getOsmIdentifier()));
 
             invalidEdges.forEach(invalidEdge ->
             {
+                this.markAsFlagged(invalidEdge.getIdentifier());
                 newFlag.addObject(invalidEdge);
                 newFlag.addInstruction(
                         this.getLocalizedInstruction(1, invalidEdge.getOsmIdentifier()));
@@ -187,7 +184,7 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<String>
     private boolean isValidCrossingEdge(final AtlasObject object)
     {
         if (Edge.isMasterEdgeIdentifier(object.getIdentifier())
-                && !TagPredicates.IS_AREA.test(object))
+                && !TagPredicates.IS_AREA.test(object) && !this.isFlagged(object.getIdentifier()))
         {
             final Optional<HighwayTag> highway = HighwayTag.highwayTag(object);
             if (highway.isPresent())

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
@@ -31,7 +31,7 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  *
  * @author mkalender, gpogulsky, bbreithaupt
  */
-public class EdgeCrossingEdgeCheck extends BaseCheck
+public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
 {
     private static final String INSTRUCTION_FORMAT = "The road with id {0,number,#} has invalid crossings."
             + " If two roads are crossing each other, then they should have nodes at intersection"

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
@@ -19,6 +19,7 @@ import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.LayerTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
@@ -26,7 +27,7 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  * they should have an intersection location shared in both edges. Otherwise, their layer tag should
  * tell the difference.
  *
- * @author mkalender, gpogulsky
+ * @author mkalender, gpogulsky, bbreithaupt
  */
 public class EdgeCrossingEdgeCheck extends BaseCheck<String>
 {
@@ -64,7 +65,7 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<String>
                 // Otherwise, if crossing edges has valid, but different tag values
                 // Then that is still a valid crossing
                 || edgeLayer.isPresent() && crossingEdgeLayer.isPresent()
-                        && !edgeLayer.orElse(0L).equals(crossingEdgeLayer.orElse(0L));
+                        && !edgeLayer.get().equals(crossingEdgeLayer.get());
     }
 
     private static String generateAtlasObjectPairIdentifier(final AtlasObject thisObject,
@@ -120,7 +121,8 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<String>
         final Edge edge = (Edge) object;
         final PolyLine edgeAsPolyLine = edge.asPolyLine();
         final Rectangle edgeBounds = edge.bounds();
-        final Optional<Long> edgeLayer = LayerTag.getTaggedValue(object);
+        final Optional<Long> edgeLayer = Validators.hasValuesFor(edge, LayerTag.class)
+                ? LayerTag.getTaggedValue(edge) : Optional.of(0L);
 
         // Retrieve crossing edges
         final Atlas atlas = object.getAtlas();
@@ -140,7 +142,8 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<String>
         for (final Edge crossingEdge : crossingEdges)
         {
             final PolyLine crossingEdgeAsPolyLine = crossingEdge.asPolyLine();
-            final Optional<Long> crossingEdgeLayer = LayerTag.getTaggedValue(crossingEdge);
+            final Optional<Long> crossingEdgeLayer = Validators.hasValuesFor(crossingEdge,
+                    LayerTag.class) ? LayerTag.getTaggedValue(crossingEdge) : Optional.of(0L);
             final Set<Location> intersections = edgeAsPolyLine
                     .intersections(crossingEdgeAsPolyLine);
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
@@ -23,9 +23,8 @@ public class EdgeCrossingEdgeCheckTest
     {
         this.verifier.actual(this.setup.invalidCrossingItemsAtlas(),
                 new EdgeCrossingEdgeCheck(this.configuration));
-        this.verifier.verifyNotEmpty();
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(flags.size(), 3));
-        this.verifier.verify(flag -> Assert.assertEquals(flag.getFlaggedObjects().size(), 2));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(4, flag.getFlaggedObjects().size()));
     }
 
     @Test
@@ -62,7 +61,7 @@ public class EdgeCrossingEdgeCheckTest
         this.verifier.actual(this.setup.invalidCrossingNonMasterItemsAtlas(),
                 new EdgeCrossingEdgeCheck(configuration));
         this.verifier.verifyNotEmpty();
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(3, flags.size()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
@@ -61,7 +61,8 @@ public class EdgeCrossingEdgeCheckTest
     {
         this.verifier.actual(this.setup.invalidCrossingNonMasterItemsAtlas(),
                 new EdgeCrossingEdgeCheck(configuration));
-        this.verifier.verifyEmpty();
+        this.verifier.verifyNotEmpty();
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(3, flags.size()));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
@@ -8,7 +8,7 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
- * @author mkalender
+ * @author mkalender, bbreithaupt
  */
 public class EdgeCrossingEdgeCheckTest
 {
@@ -50,9 +50,9 @@ public class EdgeCrossingEdgeCheckTest
     public void testInvalidCrossingItemsWithSameLayerTagAtlas()
     {
         this.verifier.actual(this.setup.invalidCrossingItemsWithSameLayerTagAtlas(),
-                new EdgeCrossingEdgeCheck(this.configuration));
-        this.verifier.verifyNotEmpty();
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(flags.size(), 2));
+                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"EdgeCrossingEdgeCheck\":{\"minimum.highway.type\":\"track\"}}")));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(flags.size(), 1));
         this.verifier.verify(flag -> Assert.assertEquals(flag.getFlaggedObjects().size(), 2));
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
@@ -10,7 +10,7 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
 /**
  * {@link EdgeCrossingEdgeCheckTest} data generator
  *
- * @author mkalender
+ * @author mkalender, bbreithaupt
  */
 public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
 {

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
@@ -28,8 +28,11 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
                     @Node(coordinates = @Loc(value = LOCATION_4)),
                     @Node(coordinates = @Loc(value = LOCATION_5)) },
             // edges
-            edges = { @Edge(coordinates = { @Loc(value = LOCATION_1), @Loc(value = LOCATION_2) }),
-                    @Edge(coordinates = { @Loc(value = LOCATION_3), @Loc(value = LOCATION_4) }) })
+            edges = {
+                    @Edge(coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
+                    @Edge(coordinates = { @Loc(value = LOCATION_3),
+                            @Loc(value = LOCATION_4) }, tags = { "highway=motorway" }) })
     private Atlas noCrossingItemsAtlas;
 
     @TestAtlas(
@@ -87,21 +90,21 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
             // edges
             edges = {
                     @Edge(id = "123456789000000", coordinates = { @Loc(value = LOCATION_3),
-                            @Loc(value = LOCATION_1) }),
+                            @Loc(value = LOCATION_1) }, tags = { "highway=motorway" }),
                     @Edge(id = "223456789000000", coordinates = { @Loc(value = LOCATION_4),
-                            @Loc(value = LOCATION_2) }),
+                            @Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
                     @Edge(id = "323456789000000", coordinates = { @Loc(value = LOCATION_5),
-                            @Loc(value = LOCATION_3) }),
+                            @Loc(value = LOCATION_3) }, tags = { "highway=motorway" }),
                     @Edge(id = "423456789000000", coordinates = { @Loc(value = LOCATION_4),
-                            @Loc(value = LOCATION_1) }),
+                            @Loc(value = LOCATION_1) }, tags = { "highway=motorway" }),
                     @Edge(id = "-123456789000000", coordinates = { @Loc(value = LOCATION_1),
-                            @Loc(value = LOCATION_3) }),
+                            @Loc(value = LOCATION_3) }, tags = { "highway=motorway" }),
                     @Edge(id = "-223456789000000", coordinates = { @Loc(value = LOCATION_2),
-                            @Loc(value = LOCATION_4) }),
+                            @Loc(value = LOCATION_4) }, tags = { "highway=motorway" }),
                     @Edge(id = "-323456789000000", coordinates = { @Loc(value = LOCATION_3),
-                            @Loc(value = LOCATION_5) }),
+                            @Loc(value = LOCATION_5) }, tags = { "highway=motorway" }),
                     @Edge(id = "-423456789000000", coordinates = { @Loc(value = LOCATION_1),
-                            @Loc(value = LOCATION_4) }) })
+                            @Loc(value = LOCATION_4) }, tags = { "highway=motorway" }) })
     private Atlas invalidCrossingNonMasterItemsAtlas;
 
     @TestAtlas(
@@ -134,13 +137,13 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
             // edges
             edges = {
                     @Edge(id = "123456789000000", coordinates = { @Loc(value = LOCATION_1),
-                            @Loc(value = LOCATION_3) }, tags = { "layer=-1" }),
+                            @Loc(value = LOCATION_3) }, tags = { "highway=motorway", "layer=-1" }),
                     @Edge(id = "223456789000000", coordinates = { @Loc(value = LOCATION_2),
-                            @Loc(value = LOCATION_4) }, tags = {}),
+                            @Loc(value = LOCATION_4) }, tags = { "highway=motorway" }),
                     @Edge(id = "323456789000000", coordinates = { @Loc(value = LOCATION_3),
-                            @Loc(value = LOCATION_5) }, tags = { "layer=1" }),
+                            @Loc(value = LOCATION_5) }, tags = { "highway=motorway", "layer=1" }),
                     @Edge(id = "423456789000000", coordinates = { @Loc(value = LOCATION_1),
-                            @Loc(value = LOCATION_4) }, tags = { "layer=2" }) })
+                            @Loc(value = LOCATION_4) }, tags = { "highway=motorway", "layer=2" }) })
     private Atlas invalidCrossingItemsWithDifferentLayerTagAtlas;
 
     @TestAtlas(
@@ -172,13 +175,13 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
             // edges
             edges = {
                     @Edge(coordinates = { @Loc(value = LOCATION_1), @Loc(value = LOCATION_2),
-                            @Loc(value = LOCATION_3) }),
+                            @Loc(value = LOCATION_3) }, tags = { "highway=motorway" }),
                     @Edge(coordinates = { @Loc(value = LOCATION_2), @Loc(value = LOCATION_3) }),
                     @Edge(coordinates = { @Loc(value = LOCATION_3), @Loc(value = LOCATION_4),
-                            @Loc(value = LOCATION_5) }),
+                            @Loc(value = LOCATION_5) }, tags = { "highway=motorway" }),
                     @Edge(coordinates = { @Loc(value = LOCATION_1), @Loc(value = LOCATION_5),
                             @Loc(value = LOCATION_3), @Loc(value = LOCATION_4),
-                            @Loc(value = LOCATION_5) }) })
+                            @Loc(value = LOCATION_5) }, tags = { "highway=motorway" }) })
     private Atlas validIntersectionItemsAtlas;
 
     public Atlas invalidCrossingItemsAtlas()


### PR DESCRIPTION
### Description:

This fixes a bug created by a change of a `LayerTag` method (see https://github.com/osmlab/atlas-checks/issues/77). The check was dependent on the default value the previous method granted. This default has been re-added, though it now takes into account the difference between a bad and non-existent layer tag. This bug should have been caught by the unit tests, but were missed due to a lack of car navigable highway tags. Unit test have been updated to address this.

This PR also includes a change to eliminate redundant flags and a new filter for highway classifications. The new filter was added to eliminate false positives from lower classification roads that can commonly cross. The redundant flags were caused by the check looking at the crossings of a single Edge and then having one of the crossing Edges have another crossing of its own that was found later. This situation was eliminated by using a BFS walker to find all connected invalid crossings. 

### Potential Impact:

Remove a large number of false positives.

### Unit Test Approach:

Unit tests were updated so that all edges have car navigable highway tags. This prevents them from being filtered out in validCheckForObject.
Some unit tests had their expected flag object count changed to reflect the new redundant flag elimination logic. 

### Test Results:

Testing showed false positive rates dropped back to expected levels after the `LayerTag` method fix. Continued testing showed another minor drop after implementing the de-duplication enhancement, but only due to flags being combined. 

