### PR TITLE
Shadow Detection Check

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -274,6 +274,14 @@
       "tags":"highway"
     }
   },
+  "ShadowDetectionCheck": {
+    "challenge": {
+      "description": "Verify the height and level tags to make sure the building does not float in 3D",
+      "blurb": "Fix floating buildings",
+      "instruction": "Open your favorite editor and check the height and placement of the building or building part for 3D alignment.",
+      "difficulty": "NORMAL"
+    }
+  },
   "SharpAngleCheck": {
     "threshold.degrees": 97.0,
     "challenge": {

--- a/docs/checks/shadowDetectionCheck.md
+++ b/docs/checks/shadowDetectionCheck.md
@@ -1,0 +1,37 @@
+# Shadow Detection Check
+
+This check flags buildings that are floating in 3D, casting abnormal shadows on the base map when rendered.
+
+In OSM, 3D buildings are achieved by assigning `height` and/or `level` tags to ways or relations that have a `building` or `building:part` tag.
+The [Simple 3D Buildings](https://wiki.openstreetmap.org/wiki/Simple_3D_buildings) osm wiki page documents much of this tagging scheme.
+Important to this check is the use of `building:min_level` and `min_height` tags to define the bottom z level of a part of a building.
+When improperly used these tags will cause building parts to become disconnected and float.  
+
+#### Live Examples
+
+1. Way [id:260580125](https://www.openstreetmap.org/way/260580125) has a `building:min_level` tag that is > 0, but their is nothing below it to connect it to the ground.
+2. Way [id:462577211](https://www.openstreetmap.org/way/462577211) has a `building:min_level` tag of 5, but the part below it, 
+way [id:462577208](https://www.openstreetmap.org/way/462577208), has a `level` tag of 4. This causes half the building to float one level above the other half.
+
+#### Code Review
+
+In [Atlas](https://github.com/osmlab/atlas), OSM elements are represented as Edges, Points, Lines, Nodes, Areas & Relations; in our case, we’re are looking at
+[Edges](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java), and
+[Relations](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java).
+
+The first process in this check is to validate incoming objects, to see if they have the potential to be floating building parts.  
+This is done by testing that each object:
+
+* is an Area or multipolygon Relation
+* has a `building` or `building:part` tag
+* has a `min_height` or `building:min_level` tag
+
+Once an object has been validated it has its `min_height` or `building:mine_level` tag checked to see if it is > 0, indicating it is off the ground.
+If it is, a BFS walker is used to find connected building parts that form a path to the ground (see the `getFloatingParts` method).
+The walker uses geographic indices and polygon overlap calculations to locate pats that overlap in 2D (see the `neighboringPart` method), 
+and then checks height and level tags to determine 3D overlap (see the `neighborsHeightContains` method). 
+When the walker is unable to find a 3D path to the ground, all the collected building parts are flagged as floating. 
+
+To learn more about the code, please look at the comments in the source code for the check.  
+[ShadowDetectionCheck](../../src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java)
+

--- a/docs/checks/shadowDetectionCheck.md
+++ b/docs/checks/shadowDetectionCheck.md
@@ -26,7 +26,7 @@ This is done by testing that each object:
 * has a `building` or `building:part` tag
 * has a `min_height` or `building:min_level` tag
 
-Once an object has been validated it has its `min_height` or `building:mine_level` tag checked to see if it is > 0, indicating it is off the ground.
+Once an object has been validated it has its `min_height` or `building:min_level` tag checked to see if it is > 0, indicating it is off the ground.
 If it is, a BFS walker is used to find connected building parts that form a path to the ground (see the `getFloatingParts` method).
 The walker uses geographic indices and polygon overlap calculations to locate pats that overlap in 2D (see the `neighboringPart` method), 
 and then checks height and level tags to determine 3D overlap (see the `neighborsHeightContains` method). 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
@@ -17,6 +17,7 @@ import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.tags.BuildingLevelsTag;
 import org.openstreetmap.atlas.tags.BuildingMinLevelTag;
 import org.openstreetmap.atlas.tags.BuildingPartTag;
+import org.openstreetmap.atlas.tags.BuildingTag;
 import org.openstreetmap.atlas.tags.HeightTag;
 import org.openstreetmap.atlas.tags.MinHeightTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
@@ -165,7 +166,8 @@ public class ShadowDetectionCheck extends BaseCheck
             final Polygon partPolygon = part.asPolygon();
             final Polygon areaPolygon = area.asPolygon();
             // Check if it is a building part, and either intersects or touches.
-            return !checked.contains(area) && this.isBuildingPart(area)
+            return !checked.contains(area)
+                    && (this.isBuildingPart(area) || BuildingTag.isBuilding(area))
                     && (partPolygon.intersects(areaPolygon)
                             || partPolygon.stream().anyMatch(areaPolygon::contains)
                             || partPolygon.fullyGeometricallyEncloses(areaPolygon)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
@@ -332,9 +332,22 @@ public class ShadowDetectionCheck extends BaseCheck
      */
     private boolean isOffGround(final AtlasObject object)
     {
-        return !object.getOsmTags().getOrDefault(MinHeightTag.KEY, ZERO_STRING).equals(ZERO_STRING)
-                || !object.getOsmTags().getOrDefault(BuildingMinLevelTag.KEY, ZERO_STRING)
-                        .equals(ZERO_STRING);
+        Double minHeight;
+        Double minLevel;
+        try
+        {
+            minHeight = Double
+                    .parseDouble(object.getOsmTags().getOrDefault(MinHeightTag.KEY, ZERO_STRING));
+            minLevel = Double.parseDouble(
+                    object.getOsmTags().getOrDefault(BuildingMinLevelTag.KEY, ZERO_STRING));
+        }
+        // We want to flag if there is a bad value
+        catch (final NumberFormatException badTagValue)
+        {
+            minHeight = 1.0;
+            minLevel = 1.0;
+        }
+        return minHeight > 0 || minLevel > 0;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
@@ -45,7 +45,7 @@ import com.google.common.collect.Range;
  *
  * @author bbreithaupt
  */
-public class ShadowDetectionCheck extends BaseCheck
+public class ShadowDetectionCheck extends BaseCheck<Long>
 {
 
     private static final long serialVersionUID = -6968080042879358551L;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
@@ -58,6 +58,7 @@ public class ShadowDetectionCheck extends BaseCheck
     // OSM standard level conversion factor
     private static final double LEVEL_TO_METERS_CONVERSION = 3.5;
     private static final String ZERO_STRING = "0";
+    private static final RelationOrAreaToMultiPolygonConverter MULTI_POLYGON_CONVERTER = new RelationOrAreaToMultiPolygonConverter();
 
     private final Map<Atlas, SpatialIndex<Relation>> relationSpatialIndices = new HashMap<>();
 
@@ -202,14 +203,14 @@ public class ShadowDetectionCheck extends BaseCheck
     private boolean neighboringPart(final AtlasObject object, final AtlasObject part,
             final Set<AtlasObject> checked)
     {
-        final RelationOrAreaToMultiPolygonConverter converter = new RelationOrAreaToMultiPolygonConverter();
         try
         {
             // Get the polygons of the parts, either single or multi
             final GeometricSurface partPolygon = part instanceof Area ? ((Area) part).asPolygon()
-                    : converter.convert((Relation) part);
+                    : MULTI_POLYGON_CONVERTER.convert((Relation) part);
             final GeometricSurface objectPolygon = object instanceof Area
-                    ? ((Area) object).asPolygon() : converter.convert((Relation) object);
+                    ? ((Area) object).asPolygon()
+                    : MULTI_POLYGON_CONVERTER.convert((Relation) object);
             // Check if it is a building part, and overlaps.
             return !checked.contains(object) && !this.isFlagged(object.getIdentifier())
                     && (this.isBuildingOrPart(object) || this.isBuildingRelationMember(object))

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.checks.validation.areas;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -23,7 +25,8 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
 import com.google.common.collect.Range;
 
 /**
- * Auto generated Check template
+ * This flags buildings and building parts that are floating, casting strange shadows when rendered
+ * in 3D.
  *
  * @author bbreithaupt
  */
@@ -32,7 +35,11 @@ public class ShadowDetectionCheck extends BaseCheck
 
     private static final long serialVersionUID = -6968080042879358551L;
 
-    private static final String BUILDING_MIN_HEIGHT_KEY = "building:min_height";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
+            "Floating building {0,number,#} has a min_level/min_height above ground level. Determine ground truth and edit accordingly.",
+            "Building Part {0,number,#} is not connected to any other building parts. Determine ground truth and edit accordingly.");
+
+    private static final double LEVEL_TO_METERS_CONVERSION = 3.5;
     private static final String ZERO_STRING = "0";
 
     /**
@@ -58,7 +65,7 @@ public class ShadowDetectionCheck extends BaseCheck
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return object instanceof Area && (this.isBuildingPart(object) || this.hasMinKey(object));
+        return object instanceof Area && this.hasMinKey(object);
     }
 
     /**
@@ -73,72 +80,149 @@ public class ShadowDetectionCheck extends BaseCheck
     {
         final Area area = (Area) object;
 
-        if (this.isBuildingPart(area))
+        // Check building parts for connection to other building parts
+        if (this.isBuildingPart(area) && !isConnectedPart(area))
         {
-            if (!isConnectedPart(area))
-            {
-                this.markAsFlagged(object.getIdentifier());
-            }
+            return Optional.of(this.createFlag(object,
+                    this.getLocalizedInstruction(1, object.getOsmIdentifier())));
+        }
+        // Flag buildings (not parts) that are floating.
+        else if (!this.isBuildingPart(area) && (!object.getOsmTags()
+                .getOrDefault(MinHeightTag.KEY, ZERO_STRING).equals(ZERO_STRING)
+                || !object.getOsmTags().getOrDefault(BuildingMinLevelTag.KEY, ZERO_STRING)
+                        .equals(ZERO_STRING)))
+        {
+            return Optional.of(this.createFlag(object,
+                    this.getLocalizedInstruction(0, object.getOsmIdentifier())));
         }
         return Optional.empty();
     }
 
+    /**
+     * Gathers the intersecting or touching building parts for an {@link Area}, and checks that they
+     * are vertically connected.
+     *
+     * @param part
+     *            an {@link Area} with tag {@code building:part=yes}, and either
+     *            {@code min_height=*} or {@code building:min_level=*}
+     * @return true if {@code part} is vertically connected to another building part
+     */
     private boolean isConnectedPart(final Area part)
     {
-        if (this.hasMinKey(part))
-        {
-            final Set<Area> neighboringParts = Iterables.asSet(part.getAtlas().areasIntersecting(
-                    part.bounds().expand(Distance.ONE_METER), neighboringPart(part)));
-            if (Validators.hasValuesFor(part, MinHeightTag.class))
-            {
-                return neighboringParts.stream().noneMatch(neighbor -> neighborsHeightContains(part,
-                        neighbor, MinHeightTag.KEY, HeightTag.KEY));
-            }
-            if (Validators.hasValuesFor(part, BuildingMinLevelTag.class))
-            {
-                return neighboringParts.stream().noneMatch(neighbor -> neighborsHeightContains(part,
-                        neighbor, BuildingMinLevelTag.KEY, BuildingLevelsTag.KEY));
-            }
-        }
-        return true;
+        // Get intersecting or touching building parts
+        final Set<Area> neighboringParts = Iterables.asSet(part.getAtlas().areasIntersecting(
+                part.bounds().expand(Distance.ONE_METER), neighboringPart(part)));
+        // Look for any vertical connection
+        return neighboringParts.stream()
+                .anyMatch(neighbor -> neighborsHeightContains(part, neighbor));
     }
 
+    /**
+     * Checks if two areas are building parts and overlap or touch each other.
+     *
+     * @param part
+     *            a known building part to check against
+     * @return true if the predicate {@link Area} is a building part and intersects or touches
+     *         {@code part}
+     */
     private Predicate<Area> neighboringPart(final Area part)
     {
         return area ->
         {
             final Polygon partPolygon = part.asPolygon();
             final Polygon areaPolygon = area.asPolygon();
+            // Check if it is a building part, and either intersects or touches.
             return this.isBuildingPart(area) && (partPolygon.fullyGeometricallyEncloses(areaPolygon)
                     || partPolygon.stream().anyMatch(areaPolygon::contains));
         };
     }
 
-    private boolean neighborsHeightContains(final Area part, final Area neighbor,
-            final String minKey, final String maxKey)
+    /**
+     * Given two {@link Area}s, checks that they have any intersecting or touching height values.
+     * The range of height values for the {@link Area}s are calculated using height and layer tags.
+     * A {@code min_height} or {@code building:min_layer} tag must exist for {@code part}. All other
+     * tags will use defaults if not found.
+     *
+     * @param part
+     *            {@link Area} being checked
+     * @param neighbor
+     *            {@lnik Area} being checked against
+     * @return true if {@code part} intersects or touches {@code neighbor}, by default neighbor is
+     *         flat on the ground.
+     */
+    private boolean neighborsHeightContains(final Area part, final Area neighbor)
     {
         final Map<String, String> neighborTags = neighbor.getOsmTags();
         final Map<String, String> partTags = part.getOsmTags();
-        if (neighborTags.containsKey(maxKey))
-        {
-            final int partMinHeight = Integer.parseInt(partTags.get(minKey));
-            final int partMaxHeight = Integer
-                    .parseInt(partTags.getOrDefault(maxKey, String.valueOf(partMinHeight)));
-            final int neighborMaxHeight = Integer.parseInt(neighborTags.get(maxKey));
-            final int neighborMinHeight = Integer
-                    .parseInt(neighborTags.getOrDefault(minKey, ZERO_STRING));
+        final double partMinHeight;
+        final double partMaxHeight;
+        double neighborMinHeight = 0;
+        double neighborMaxHeight = 0;
 
-            return Range.closed(partMinHeight, partMaxHeight)
-                    .isConnected(Range.closed(neighborMinHeight, neighborMaxHeight));
+        // Set partMinHeight
+        partMinHeight = partTags.containsKey(MinHeightTag.KEY)
+                ? Integer.parseInt(partTags.get(MinHeightTag.KEY))
+                : Integer.parseInt(partTags.get(BuildingMinLevelTag.KEY))
+                        * LEVEL_TO_METERS_CONVERSION;
+        // Set partMaxHeight
+        if (partTags.containsKey(HeightTag.KEY))
+        {
+            partMaxHeight = Integer.parseInt(partTags.get(HeightTag.KEY));
         }
-        return false;
+        else if (partTags.containsKey(BuildingLevelsTag.KEY))
+        {
+            partMaxHeight = Integer.parseInt(partTags.get(BuildingLevelsTag.KEY))
+                    * LEVEL_TO_METERS_CONVERSION;
+        }
+        else
+        {
+            partMaxHeight = partMinHeight;
+        }
+        // Set neighborMinHeight
+        if (neighborTags.containsKey(MinHeightTag.KEY))
+        {
+            neighborMinHeight = Integer.parseInt(neighborTags.get(MinHeightTag.KEY));
+        }
+        else if (neighborTags.containsKey(BuildingMinLevelTag.KEY))
+        {
+            neighborMinHeight = Integer.parseInt(neighborTags.get(BuildingMinLevelTag.KEY))
+                    * LEVEL_TO_METERS_CONVERSION;
+        }
+        // Set neighborMaxHeight
+        if (neighborTags.containsKey(HeightTag.KEY))
+        {
+            neighborMaxHeight = Integer.parseInt(neighborTags.get(HeightTag.KEY));
+        }
+        else if (neighborTags.containsKey(BuildingLevelsTag.KEY))
+        {
+            neighborMaxHeight = Integer.parseInt(neighborTags.get(BuildingLevelsTag.KEY))
+                    * LEVEL_TO_METERS_CONVERSION;
+        }
+
+        // Check the range of heights for overlap.
+        return Range.closed(partMinHeight, partMaxHeight)
+                .isConnected(Range.closed(neighborMinHeight, neighborMaxHeight));
     }
 
+    /**
+     * Checks if an {@link AtlasObject} is a building part.
+     *
+     * @param object
+     *            {@link AtlasObject} to check
+     * @return true if {@code object} has a {@code building:part=yes} tag
+     */
     private boolean isBuildingPart(final AtlasObject object)
     {
         return Validators.isOfType(object, BuildingPartTag.class, BuildingPartTag.YES);
     }
 
+    /**
+     * Checks if an {@link AtlasObject} has a tag defining the minimum height of a building.
+     *
+     * @param object
+     *            {@link AtlasObject} to check
+     * @return true if {@code object} has a tag defining the minimum height of a building
+     */
     private boolean hasMinKey(final AtlasObject object)
     {
         return Validators.hasValuesFor(object, BuildingMinLevelTag.class)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
@@ -156,7 +156,7 @@ public class ShadowDetectionCheck extends BaseCheck
             final Polygon partPolygon = part.asPolygon();
             final Polygon areaPolygon = area.asPolygon();
             // Check if it is a building part, and either intersects or touches.
-            return !checked.contains(area)
+            return !checked.contains(area) && !this.isFlagged(area.getIdentifier())
                     && (this.isBuildingPart(area) || BuildingTag.isBuilding(area))
                     && (partPolygon.intersects(areaPolygon)
                             || partPolygon.stream().anyMatch(areaPolygon::contains)
@@ -190,17 +190,17 @@ public class ShadowDetectionCheck extends BaseCheck
 
         // Set partMinHeight
         partMinHeight = partTags.containsKey(MinHeightTag.KEY)
-                ? Integer.parseInt(partTags.get(MinHeightTag.KEY))
-                : Integer.parseInt(partTags.get(BuildingMinLevelTag.KEY))
+                ? Double.parseDouble(partTags.get(MinHeightTag.KEY))
+                : Double.parseDouble(partTags.get(BuildingMinLevelTag.KEY))
                         * LEVEL_TO_METERS_CONVERSION;
         // Set partMaxHeight
         if (partTags.containsKey(HeightTag.KEY))
         {
-            partMaxHeight = Integer.parseInt(partTags.get(HeightTag.KEY));
+            partMaxHeight = Double.parseDouble(partTags.get(HeightTag.KEY));
         }
         else if (partTags.containsKey(BuildingLevelsTag.KEY))
         {
-            partMaxHeight = Integer.parseInt(partTags.get(BuildingLevelsTag.KEY))
+            partMaxHeight = Double.parseDouble(partTags.get(BuildingLevelsTag.KEY))
                     * LEVEL_TO_METERS_CONVERSION;
         }
         else
@@ -210,27 +210,34 @@ public class ShadowDetectionCheck extends BaseCheck
         // Set neighborMinHeight
         if (neighborTags.containsKey(MinHeightTag.KEY))
         {
-            neighborMinHeight = Integer.parseInt(neighborTags.get(MinHeightTag.KEY));
+            neighborMinHeight = Double.parseDouble(neighborTags.get(MinHeightTag.KEY));
         }
         else if (neighborTags.containsKey(BuildingMinLevelTag.KEY))
         {
-            neighborMinHeight = Integer.parseInt(neighborTags.get(BuildingMinLevelTag.KEY))
+            neighborMinHeight = Double.parseDouble(neighborTags.get(BuildingMinLevelTag.KEY))
                     * LEVEL_TO_METERS_CONVERSION;
         }
         // Set neighborMaxHeight
         if (neighborTags.containsKey(HeightTag.KEY))
         {
-            neighborMaxHeight = Integer.parseInt(neighborTags.get(HeightTag.KEY));
+            neighborMaxHeight = Double.parseDouble(neighborTags.get(HeightTag.KEY));
         }
         else if (neighborTags.containsKey(BuildingLevelsTag.KEY))
         {
-            neighborMaxHeight = Integer.parseInt(neighborTags.get(BuildingLevelsTag.KEY))
+            neighborMaxHeight = Double.parseDouble(neighborTags.get(BuildingLevelsTag.KEY))
                     * LEVEL_TO_METERS_CONVERSION;
         }
 
         // Check the range of heights for overlap.
-        return Range.closed(partMinHeight, partMaxHeight)
-                .isConnected(Range.closed(neighborMinHeight, neighborMaxHeight));
+        try
+        {
+            return Range.closed(partMinHeight, partMaxHeight)
+                    .isConnected(Range.closed(neighborMinHeight, neighborMaxHeight));
+        }
+        catch (final IllegalArgumentException exc)
+        {
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
@@ -296,7 +296,7 @@ public class ShadowDetectionCheck extends BaseCheck
                 return Range.closed(partMinHeight, partMaxHeight)
                         .isConnected(Range.closed(neighborMinHeight, neighborMaxHeight));
             }
-            // Ignore buildings with a min value lager than its height
+            // Ignore buildings with a min value larger than its height
             catch (final IllegalArgumentException exc)
             {
                 return false;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
@@ -141,7 +141,8 @@ public class ShadowDetectionCheck extends BaseCheck
             return !area.equals(part) && this.isBuildingPart(area)
                     && (partPolygon.intersects(areaPolygon)
                             || partPolygon.stream().anyMatch(areaPolygon::contains)
-                            || partPolygon.fullyGeometricallyEncloses(areaPolygon));
+                            || partPolygon.fullyGeometricallyEncloses(areaPolygon)
+                            || areaPolygon.fullyGeometricallyEncloses(partPolygon));
         };
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
@@ -98,6 +98,12 @@ public class ShadowDetectionCheck extends BaseCheck
         return Optional.empty();
     }
 
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
     /**
      * Gathers the intersecting or touching building parts for an {@link Area}, and checks that they
      * are vertically connected.
@@ -132,8 +138,10 @@ public class ShadowDetectionCheck extends BaseCheck
             final Polygon partPolygon = part.asPolygon();
             final Polygon areaPolygon = area.asPolygon();
             // Check if it is a building part, and either intersects or touches.
-            return this.isBuildingPart(area) && (partPolygon.fullyGeometricallyEncloses(areaPolygon)
-                    || partPolygon.stream().anyMatch(areaPolygon::contains));
+            return !area.equals(part) && this.isBuildingPart(area)
+                    && (partPolygon.intersects(areaPolygon)
+                            || partPolygon.stream().anyMatch(areaPolygon::contains)
+                            || partPolygon.fullyGeometricallyEncloses(areaPolygon));
         };
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
@@ -1,0 +1,147 @@
+package org.openstreetmap.atlas.checks.validation.areas;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.atlas.items.Area;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.tags.BuildingLevelsTag;
+import org.openstreetmap.atlas.tags.BuildingMinLevelTag;
+import org.openstreetmap.atlas.tags.BuildingPartTag;
+import org.openstreetmap.atlas.tags.HeightTag;
+import org.openstreetmap.atlas.tags.MinHeightTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
+import com.google.common.collect.Range;
+
+/**
+ * Auto generated Check template
+ *
+ * @author bbreithaupt
+ */
+public class ShadowDetectionCheck extends BaseCheck
+{
+
+    private static final long serialVersionUID = -6968080042879358551L;
+
+    private static final String BUILDING_MIN_HEIGHT_KEY = "building:min_height";
+    private static final String ZERO_STRING = "0";
+
+    /**
+     * The default constructor that must be supplied. The Atlas Checks framework will generate the
+     * checks with this constructor, supplying a configuration that can be used to adjust any
+     * parameters that the check uses during operation.
+     *
+     * @param configuration
+     *            the JSON configuration for this check
+     */
+    public ShadowDetectionCheck(final Configuration configuration)
+    {
+        super(configuration);
+    }
+
+    /**
+     * This function will validate if the supplied atlas object is valid for the check.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return {@code true} if this object should be checked
+     */
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return object instanceof Area && (this.isBuildingPart(object) || this.hasMinKey(object));
+    }
+
+    /**
+     * This is the actual function that will check to see whether the object needs to be flagged.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return an optional {@link CheckFlag} object that
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final Area area = (Area) object;
+
+        if (this.isBuildingPart(area))
+        {
+            if (!isConnectedPart(area))
+            {
+                this.markAsFlagged(object.getIdentifier());
+            }
+        }
+        return Optional.empty();
+    }
+
+    private boolean isConnectedPart(final Area part)
+    {
+        if (this.hasMinKey(part))
+        {
+            final Set<Area> neighboringParts = Iterables.asSet(part.getAtlas().areasIntersecting(
+                    part.bounds().expand(Distance.ONE_METER), neighboringPart(part)));
+            if (Validators.hasValuesFor(part, MinHeightTag.class))
+            {
+                return neighboringParts.stream().noneMatch(neighbor -> neighborsHeightContains(part,
+                        neighbor, MinHeightTag.KEY, HeightTag.KEY));
+            }
+            if (Validators.hasValuesFor(part, BuildingMinLevelTag.class))
+            {
+                return neighboringParts.stream().noneMatch(neighbor -> neighborsHeightContains(part,
+                        neighbor, BuildingMinLevelTag.KEY, BuildingLevelsTag.KEY));
+            }
+        }
+        return true;
+    }
+
+    private Predicate<Area> neighboringPart(final Area part)
+    {
+        return area ->
+        {
+            final Polygon partPolygon = part.asPolygon();
+            final Polygon areaPolygon = area.asPolygon();
+            return this.isBuildingPart(area) && (partPolygon.fullyGeometricallyEncloses(areaPolygon)
+                    || partPolygon.stream().anyMatch(areaPolygon::contains));
+        };
+    }
+
+    private boolean neighborsHeightContains(final Area part, final Area neighbor,
+            final String minKey, final String maxKey)
+    {
+        final Map<String, String> neighborTags = neighbor.getOsmTags();
+        final Map<String, String> partTags = part.getOsmTags();
+        if (neighborTags.containsKey(maxKey))
+        {
+            final int partMinHeight = Integer.parseInt(partTags.get(minKey));
+            final int partMaxHeight = Integer
+                    .parseInt(partTags.getOrDefault(maxKey, String.valueOf(partMinHeight)));
+            final int neighborMaxHeight = Integer.parseInt(neighborTags.get(maxKey));
+            final int neighborMinHeight = Integer
+                    .parseInt(neighborTags.getOrDefault(minKey, ZERO_STRING));
+
+            return Range.closed(partMinHeight, partMaxHeight)
+                    .isConnected(Range.closed(neighborMinHeight, neighborMaxHeight));
+        }
+        return false;
+    }
+
+    private boolean isBuildingPart(final AtlasObject object)
+    {
+        return Validators.isOfType(object, BuildingPartTag.class, BuildingPartTag.YES);
+    }
+
+    private boolean hasMinKey(final AtlasObject object)
+    {
+        return Validators.hasValuesFor(object, BuildingMinLevelTag.class)
+                || Validators.hasValuesFor(object, MinHeightTag.class);
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
@@ -50,7 +50,8 @@ public class ShadowDetectionCheck extends BaseCheck
     private static final long serialVersionUID = -6968080042879358551L;
 
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
-            "The building(s) and/or building part(s) float(s) above the ground. Please check the height/building:levels and min_height/building:min_level tags.");
+            "The building(s) and/or building part(s) float(s) above the ground. Please check the height/building:levels and min_height/building:min_level tags.",
+            "Relation {0,number,#} is floating.");
 
     private static final double LEVEL_TO_METERS_CONVERSION = 3.5;
     private static final String ZERO_STRING = "0";
@@ -104,12 +105,12 @@ public class ShadowDetectionCheck extends BaseCheck
             if (object instanceof Relation)
             {
                 flag = this.createFlag(this.flatten((Relation) object),
-                        this.getLocalizedInstruction(0, object.getOsmIdentifier()));
+                        this.getLocalizedInstruction(0));
+                flag.addInstruction(this.getLocalizedInstruction(1, object.getOsmIdentifier()));
             }
             else
             {
-                flag = this.createFlag(object,
-                        this.getLocalizedInstruction(0, object.getOsmIdentifier()));
+                flag = this.createFlag(object, this.getLocalizedInstruction(0));
             }
             for (final AtlasObject part : floatingParts)
             {
@@ -119,6 +120,8 @@ public class ShadowDetectionCheck extends BaseCheck
                     if (part instanceof Relation)
                     {
                         flag.addObjects(this.flatten((Relation) part));
+                        flag.addInstruction(
+                                this.getLocalizedInstruction(1, part.getOsmIdentifier()));
                     }
                     else
                     {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
@@ -135,10 +135,12 @@ public class ShadowDetectionCheck extends BaseCheck
         while (!toCheck.isEmpty())
         {
             final Area checking = toCheck.poll();
-            if (!isOffGround(checking))
+            // If a connection to the ground is found the parts are not floating
+            if (!isOffGround(checking) && connectedParts.size() > 1)
             {
                 return new HashSet<>();
             }
+            // Get parts connected in 3D
             final Set<Area> neighboringParts = Iterables.asSet(checking.getAtlas()
                     .areasIntersecting(checking.bounds().expand(Distance.ONE_METER),
                             neighboringPart(checking, connectedParts)));

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
@@ -113,4 +113,13 @@ public class ShadowDetectionCheckTest
                 new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
+
+    @Test
+    public void invalidBuildingPartsManyFloatTest()
+    {
+        this.verifier.actual(this.setup.invalidBuildingPartsManyFloatAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(3, flag.getFlaggedObjects().size()));
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
@@ -83,6 +83,22 @@ public class ShadowDetectionCheckTest
     }
 
     @Test
+    public void validBuildingPartsEnclosePartTest()
+    {
+        this.verifier.actual(this.setup.validBuildingPartsEnclosePartAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validBuildingPartsEncloseNeighborTest()
+    {
+        this.verifier.actual(this.setup.validBuildingPartsEncloseNeighborAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
     public void validBuildingPartsStackedTest()
     {
         this.verifier.actual(this.setup.validBuildingPartsStackedAtlas(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
@@ -43,6 +43,14 @@ public class ShadowDetectionCheckTest
     }
 
     @Test
+    public void validBuildingRoofTest()
+    {
+        this.verifier.actual(this.setup.validBuildingRoofAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
     public void invalidFloatingHeightBuildingTest()
     {
         this.verifier.actual(this.setup.invalidFloatingHeightBuildingAtlas(),
@@ -194,8 +202,7 @@ public class ShadowDetectionCheckTest
     {
         this.verifier.actual(this.setup.invalidUntaggedAreasStackedAtlas(),
                 new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(1, flag.getFlaggedObjects().size()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
@@ -115,6 +115,14 @@ public class ShadowDetectionCheckTest
     }
 
     @Test
+    public void validBuildingAndPartStackedTest()
+    {
+        this.verifier.actual(this.setup.validBuildingAndPartStackedAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
     public void invalidBuildingPartsManyFloatTest()
     {
         this.verifier.actual(this.setup.invalidBuildingPartsManyFloatAtlas(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
@@ -27,6 +27,22 @@ public class ShadowDetectionCheckTest
     }
 
     @Test
+    public void validBuildingBadMinTest()
+    {
+        this.verifier.actual(this.setup.validBuildingBadMinAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void invalidBuildingBadMinTest()
+    {
+        this.verifier.actual(this.setup.invalidBuildingBadMinAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
     public void invalidFloatingHeightBuildingTest()
     {
         this.verifier.actual(this.setup.invalidFloatingHeightBuildingAtlas(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
@@ -122,4 +122,12 @@ public class ShadowDetectionCheckTest
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(3, flag.getFlaggedObjects().size()));
     }
+
+    @Test
+    public void invalidBuildingPartSingleAtlas()
+    {
+        this.verifier.actual(this.setup.invalidBuildingPartSingleAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
@@ -190,6 +190,23 @@ public class ShadowDetectionCheckTest
     }
 
     @Test
+    public void invalidUntaggedAreasStackedTest()
+    {
+        this.verifier.actual(this.setup.invalidUntaggedAreasStackedAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(1, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void validUntaggedAreasStackedBuildingRelationTest()
+    {
+        this.verifier.actual(this.setup.validUntaggedAreasStackedBuildingRelationAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
     public void invalidBuildingPartsManyFloatTest()
     {
         this.verifier.actual(this.setup.invalidBuildingPartsManyFloatAtlas(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
@@ -1,0 +1,100 @@
+package org.openstreetmap.atlas.checks.validation.areas;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * Unit tests for {@link ShadowDetectionCheck}.
+ *
+ * @author bbreithaupt
+ */
+public class ShadowDetectionCheckTest
+{
+    @Rule
+    public ShadowDetectionCheckTestRule setup = new ShadowDetectionCheckTestRule();
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void validBuildingTest()
+    {
+        this.verifier.actual(this.setup.validBuildingAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void invalidFloatingHeightBuildingTest()
+    {
+        this.verifier.actual(this.setup.invalidFloatingHeightBuildingAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void invalidFloatingLevelBuildingTest()
+    {
+        this.verifier.actual(this.setup.invalidFloatingLevelBuildingAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void validBuildingPartsTouchTest()
+    {
+        this.verifier.actual(this.setup.validBuildingPartsTouchAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validBuildingPartsTouchGroundTest()
+    {
+        this.verifier.actual(this.setup.validBuildingPartsTouchGroundAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validBuildingPartsIntersectTest()
+    {
+        this.verifier.actual(this.setup.validBuildingPartsIntersectAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void invalidBuildingPartsIntersectTest()
+    {
+        this.verifier.actual(this.setup.invalidBuildingPartsIntersectAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void invalidBuildingPartsDisparateTest()
+    {
+        this.verifier.actual(this.setup.invalidBuildingPartsDisparateAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void validBuildingPartsStackedTest()
+    {
+        this.verifier.actual(this.setup.validBuildingPartsStackedAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validBuildingPartsStackedMixedTagsTest()
+    {
+        this.verifier.actual(this.setup.validBuildingPartsStackedMixedTagsAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
@@ -43,6 +43,22 @@ public class ShadowDetectionCheckTest
     }
 
     @Test
+    public void validFloatingLevelRelationBuildingTest()
+    {
+        this.verifier.actual(this.setup.validFloatingLevelRelationBuildingAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void invalidFloatingLevelRelationBuildingTest()
+    {
+        this.verifier.actual(this.setup.invalidFloatingLevelRelationBuildingAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
     public void validBuildingPartsTouchTest()
     {
         this.verifier.actual(this.setup.validBuildingPartsTouchAtlas(),
@@ -126,6 +142,23 @@ public class ShadowDetectionCheckTest
     public void invalidBuildingAndPartStackedTest()
     {
         this.verifier.actual(this.setup.invalidBuildingAndPartStackedAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void validBuildingRelationAndPartStackedTest()
+    {
+        this.verifier.actual(this.setup.validBuildingRelationAndPartStackedAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void invalidBuildingRelationAndPartStackedTest()
+    {
+        this.verifier.actual(this.setup.invalidBuildingRelationAndPartStackedAtlas(),
                 new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
@@ -123,6 +123,24 @@ public class ShadowDetectionCheckTest
     }
 
     @Test
+    public void invalidBuildingAndPartStackedTest()
+    {
+        this.verifier.actual(this.setup.invalidBuildingAndPartStackedAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void invalidBuildingsStackedTest()
+    {
+        this.verifier.actual(this.setup.invalidBuildingsStackedAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
     public void invalidBuildingPartsManyFloatTest()
     {
         this.verifier.actual(this.setup.invalidBuildingPartsManyFloatAtlas(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
@@ -1,0 +1,178 @@
+package org.openstreetmap.atlas.checks.validation.areas;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+
+/**
+ * Unit test atlases for {@link ShadowDetectionCheck}.
+ *
+ * @author bbreithaupt
+ */
+public class ShadowDetectionCheckTestRule extends CoreTestRule
+{
+    private static final String TEST_1 = "47.2464747377508,-122.438262777482";
+    private static final String TEST_2 = "47.2464428615188,-122.438065168917";
+    private static final String TEST_3 = "47.2464096570902,-122.438284299207";
+    private static final String TEST_4 = "47.2463698117484,-122.438047560233";
+    private static final String TEST_5 = "47.246340591812,-122.438307777452";
+    private static final String TEST_6 = "47.2462967618771,-122.438029951549";
+    private static final String TEST_7 = "47.2462635573569,-122.438335168739";
+    private static final String TEST_8 = "47.2462223837229,-122.438018212427";
+
+    @TestAtlas(
+            // areas
+            areas = { @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                    @Loc(value = TEST_4),
+                    @Loc(value = TEST_3) }, tags = { "building=yes", "height=20" }) })
+    private Atlas validBuildingAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = { @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                    @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building=yes",
+                            "height=20", "min_height=3" }) })
+    private Atlas invalidFloatingHeightBuildingAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = { @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                    @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building=yes",
+                            "building:levels=5", "building:min_level=1" }) })
+    private Atlas invalidFloatingLevelBuildingAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = {
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = {
+                                    "building:part=yes", "building:levels=5" }),
+                    @Area(coordinates = { @Loc(value = TEST_3), @Loc(value = TEST_4),
+                            @Loc(value = TEST_6), @Loc(value = TEST_5) }, tags = {
+                                    "building:part=yes", "building:levels=8",
+                                    "building:min_level=1" }) })
+    private Atlas validBuildingPartsTouchAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = {
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = {
+                                    "building:part=yes", "building:levels=5" }),
+                    @Area(coordinates = { @Loc(value = TEST_3), @Loc(value = TEST_4),
+                            @Loc(value = TEST_6), @Loc(value = TEST_5) }, tags = {
+                                    "building:part=yes", "building:levels=8",
+                                    "building:min_level=0" }) })
+    private Atlas validBuildingPartsTouchGroundAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = {
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_6), @Loc(value = TEST_5) }, tags = {
+                                    "building:part=yes", "building:levels=5" }),
+                    @Area(coordinates = { @Loc(value = TEST_3), @Loc(value = TEST_4),
+                            @Loc(value = TEST_7), @Loc(value = TEST_8) }, tags = {
+                                    "building:part=yes", "building:levels=8",
+                                    "building:min_level=1" }) })
+    private Atlas validBuildingPartsIntersectAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = {
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_6), @Loc(value = TEST_5) }, tags = {
+                                    "building:part=yes", "building:levels=5" }),
+                    @Area(coordinates = { @Loc(value = TEST_3), @Loc(value = TEST_4),
+                            @Loc(value = TEST_7), @Loc(value = TEST_8) }, tags = {
+                                    "building:part=yes", "building:levels=8",
+                                    "building:min_level=6" }) })
+    private Atlas invalidBuildingPartsIntersectAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = {
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = {
+                                    "building:part=yes", "building:levels=5" }),
+                    @Area(coordinates = { @Loc(value = TEST_5), @Loc(value = TEST_6),
+                            @Loc(value = TEST_8), @Loc(value = TEST_7) }, tags = {
+                                    "building:part=yes", "building:levels=8",
+                                    "building:min_level=4" }) })
+    private Atlas invalidBuildingPartsDisparateAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = {
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = {
+                                    "building:part=yes", "building:levels=5" }),
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_6), @Loc(value = TEST_5) }, tags = {
+                                    "building:part=yes", "building:levels=8",
+                                    "building:min_level=5" }) })
+    private Atlas validBuildingPartsStackedAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = {
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = {
+                                    "building:part=yes", "building:levels=5" }),
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_6), @Loc(value = TEST_5) }, tags = {
+                                    "building:part=yes", "height=30", "min_height=17.5" }) })
+    private Atlas validBuildingPartsStackedMixedTagsAtlas;
+
+    public Atlas validBuildingAtlas()
+    {
+        return this.validBuildingAtlas;
+    }
+
+    public Atlas invalidFloatingHeightBuildingAtlas()
+    {
+        return this.invalidFloatingHeightBuildingAtlas;
+    }
+
+    public Atlas invalidFloatingLevelBuildingAtlas()
+    {
+        return this.invalidFloatingLevelBuildingAtlas;
+    }
+
+    public Atlas validBuildingPartsTouchAtlas()
+    {
+        return this.validBuildingPartsTouchAtlas;
+    }
+
+    public Atlas validBuildingPartsTouchGroundAtlas()
+    {
+        return this.validBuildingPartsTouchGroundAtlas;
+    }
+
+    public Atlas validBuildingPartsIntersectAtlas()
+    {
+        return this.validBuildingPartsIntersectAtlas;
+    }
+
+    public Atlas invalidBuildingPartsIntersectAtlas()
+    {
+        return this.invalidBuildingPartsIntersectAtlas;
+    }
+
+    public Atlas invalidBuildingPartsDisparateAtlas()
+    {
+        return this.invalidBuildingPartsDisparateAtlas;
+    }
+
+    public Atlas validBuildingPartsStackedAtlas()
+    {
+        return this.validBuildingPartsStackedAtlas;
+    }
+
+    public Atlas validBuildingPartsStackedMixedTagsAtlas()
+    {
+        return this.validBuildingPartsStackedMixedTagsAtlas;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
@@ -151,6 +151,18 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
 
     @TestAtlas(
             // areas
+            areas = {
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = {
+                            "building=yes", "building:levels=5" }),
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_6), @Loc(value = TEST_5) }, tags = {
+                            "building:part=yes", "building:levels=8",
+                            "building:min_level=5" }) })
+    private Atlas validBuildingAndPartStackedAtlas;
+
+    @TestAtlas(
+            // areas
             areas = { @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                     @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building:part=yes",
                             "building:levels=8", "building:min_level=5" }),
@@ -170,6 +182,8 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
                     @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building:part=yes",
                             "height=20", "min_height=5" }) })
     private Atlas invalidBuildingPartSingleAtlas;
+
+
 
     public Atlas validBuildingAtlas()
     {
@@ -229,6 +243,11 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     public Atlas validBuildingPartsStackedMixedTagsAtlas()
     {
         return this.validBuildingPartsStackedMixedTagsAtlas;
+    }
+
+    public Atlas validBuildingAndPartStackedAtlas()
+    {
+        return this.validBuildingAndPartStackedAtlas;
     }
 
     public Atlas invalidBuildingPartsManyFloatAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
@@ -50,6 +50,13 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     @TestAtlas(
             // areas
             areas = { @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                    @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building=roof",
+                            "height=20", "min_height=bad" }) })
+    private Atlas validBuildingRoofAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = { @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                     @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building=yes",
                             "height=20", "min_height=3" }) })
     private Atlas invalidFloatingHeightBuildingAtlas;
@@ -313,6 +320,11 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     public Atlas invalidBuildingBadMinAtlas()
     {
         return this.invalidBuildingBadMinAtlas;
+    }
+
+    public Atlas validBuildingRoofAtlas()
+    {
+        return this.validBuildingRoofAtlas;
     }
 
     public Atlas invalidFloatingHeightBuildingAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
@@ -153,13 +153,36 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
             // areas
             areas = {
                     @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
-                            @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = {
-                            "building=yes", "building:levels=5" }),
+                            @Loc(value = TEST_4),
+                            @Loc(value = TEST_3) }, tags = { "building=yes", "building:levels=5" }),
                     @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                             @Loc(value = TEST_6), @Loc(value = TEST_5) }, tags = {
-                            "building:part=yes", "building:levels=8",
-                            "building:min_level=5" }) })
+                                    "building:part=yes", "building:levels=8",
+                                    "building:min_level=5" }) })
     private Atlas validBuildingAndPartStackedAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = {
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building=yes",
+                                    "building:levels=5", "building:min_level=2" }),
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_6), @Loc(value = TEST_5) }, tags = {
+                                    "building:part=yes", "building:levels=8",
+                                    "building:min_level=5" }) })
+    private Atlas invalidBuildingAndPartStackedAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = {
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building=yes",
+                                    "building:levels=5", "building:min_level=2" }),
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_6), @Loc(value = TEST_5) }, tags = { "building=yes",
+                                    "building:levels=8", "building:min_level=5" }) })
+    private Atlas invalidBuildingsStackedAtlas;
 
     @TestAtlas(
             // areas
@@ -182,8 +205,6 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
                     @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building:part=yes",
                             "height=20", "min_height=5" }) })
     private Atlas invalidBuildingPartSingleAtlas;
-
-
 
     public Atlas validBuildingAtlas()
     {
@@ -248,6 +269,16 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     public Atlas validBuildingAndPartStackedAtlas()
     {
         return this.validBuildingAndPartStackedAtlas;
+    }
+
+    public Atlas invalidBuildingAndPartStackedAtlas()
+    {
+        return this.invalidBuildingAndPartStackedAtlas;
+    }
+
+    public Atlas invalidBuildingsStackedAtlas()
+    {
+        return this.invalidBuildingsStackedAtlas;
     }
 
     public Atlas invalidBuildingPartsManyFloatAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
@@ -37,6 +37,20 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
             // areas
             areas = { @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                     @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building=yes",
+                            "height=20", "min_height=-8" }) })
+    private Atlas validBuildingBadMinAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = { @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                    @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building=yes",
+                            "height=20", "min_height=bad" }) })
+    private Atlas invalidBuildingBadMinAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = { @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                    @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building=yes",
                             "height=20", "min_height=3" }) })
     private Atlas invalidFloatingHeightBuildingAtlas;
 
@@ -263,6 +277,16 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     public Atlas validBuildingAtlas()
     {
         return this.validBuildingAtlas;
+    }
+
+    public Atlas validBuildingBadMinAtlas()
+    {
+        return this.validBuildingBadMinAtlas;
+    }
+
+    public Atlas invalidBuildingBadMinAtlas()
+    {
+        return this.invalidBuildingBadMinAtlas;
     }
 
     public Atlas invalidFloatingHeightBuildingAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
@@ -21,6 +21,8 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     private static final String TEST_6 = "47.2462967618771,-122.438029951549";
     private static final String TEST_7 = "47.2462635573569,-122.438335168739";
     private static final String TEST_8 = "47.2462223837229,-122.438018212427";
+    private static final String TEST_9 = "47.2463100436794,-122.438112125408";
+    private static final String TEST_10 = "47.2464295797499,-122.437949734211";
 
     @TestAtlas(
             // areas
@@ -106,6 +108,27 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     @TestAtlas(
             // areas
             areas = {
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_10),
+                            @Loc(value = TEST_8), @Loc(value = TEST_7) }, tags = {
+                                    "building:part=yes", "building:levels=5" }),
+                    @Area(coordinates = { @Loc(value = TEST_4), @Loc(value = TEST_6),
+                            @Loc(value = TEST_9) }, tags = { "building:part=yes",
+                                    "building:levels=8", "building:min_level=1" }) })
+    private Atlas validBuildingPartsEnclosePartAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = { @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_10),
+                    @Loc(value = TEST_8), @Loc(value = TEST_7) }, tags = { "building:part=yes",
+                            "building:levels=5", "building:min_level=1" }),
+                    @Area(coordinates = { @Loc(value = TEST_4), @Loc(value = TEST_6),
+                            @Loc(value = TEST_9) }, tags = { "building:part=yes",
+                                    "building:levels=8" }) })
+    private Atlas validBuildingPartsEncloseNeighborAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = {
                     @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                             @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = {
                                     "building:part=yes", "building:levels=5" }),
@@ -164,6 +187,16 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     public Atlas invalidBuildingPartsDisparateAtlas()
     {
         return this.invalidBuildingPartsDisparateAtlas;
+    }
+
+    public Atlas validBuildingPartsEnclosePartAtlas()
+    {
+        return this.validBuildingPartsEnclosePartAtlas;
+    }
+
+    public Atlas validBuildingPartsEncloseNeighborAtlas()
+    {
+        return this.validBuildingPartsEncloseNeighborAtlas;
     }
 
     public Atlas validBuildingPartsStackedAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
@@ -5,6 +5,8 @@ import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
 
 /**
  * Unit test atlases for {@link ShadowDetectionCheck}.
@@ -44,6 +46,27 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
                     @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building=yes",
                             "building:levels=5", "building:min_level=1" }) })
     private Atlas invalidFloatingLevelBuildingAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = { @Area(id = "1000000", coordinates = { @Loc(value = TEST_1),
+                    @Loc(value = TEST_2), @Loc(value = TEST_4), @Loc(value = TEST_3) }) },
+            // relation
+            relations = { @Relation(members = {
+                    @Member(id = "1000000", type = "area", role = "outer") }, tags = {
+                            "type=multipolygon", "building=yes", "building:levels=5" }) })
+    private Atlas validFloatingLevelRelationBuildingAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = { @Area(id = "1000000", coordinates = { @Loc(value = TEST_1),
+                    @Loc(value = TEST_2), @Loc(value = TEST_4), @Loc(value = TEST_3) }) },
+            // relation
+            relations = { @Relation(members = {
+                    @Member(id = "1000000", type = "area", role = "outer") }, tags = {
+                            "type=multipolygon", "building=yes", "building:levels=5",
+                            "building:min_level=1" }) })
+    private Atlas invalidFloatingLevelRelationBuildingAtlas;
 
     @TestAtlas(
             // areas
@@ -176,6 +199,37 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     @TestAtlas(
             // areas
             areas = {
+                    @Area(id = "1000000", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2), @Loc(value = TEST_4), @Loc(value = TEST_3) }),
+                    @Area(id = "2000000", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2), @Loc(value = TEST_6),
+                            @Loc(value = TEST_5) }, tags = { "building:part=yes",
+                                    "building:levels=8", "building:min_level=5" }) },
+            // relation
+            relations = { @Relation(members = {
+                    @Member(id = "1000000", type = "area", role = "outer") }, tags = {
+                            "type=multipolygon", "building=yes", "building:levels=5" }) })
+    private Atlas validBuildingRelationAndPartStackedAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = {
+                    @Area(id = "1000000", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2), @Loc(value = TEST_4), @Loc(value = TEST_3) }),
+                    @Area(id = "2000000", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2), @Loc(value = TEST_6),
+                            @Loc(value = TEST_5) }, tags = { "building:part=yes",
+                                    "building:levels=8", "building:min_level=5" }) },
+            // relation
+            relations = { @Relation(members = {
+                    @Member(id = "1000000", type = "area", role = "outer") }, tags = {
+                            "type=multipolygon", "building=yes", "building:levels=5",
+                            "building:min_level=1" }) })
+    private Atlas invalidBuildingRelationAndPartStackedAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = {
                     @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                             @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building=yes",
                                     "building:levels=5", "building:min_level=2" }),
@@ -219,6 +273,16 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     public Atlas invalidFloatingLevelBuildingAtlas()
     {
         return this.invalidFloatingLevelBuildingAtlas;
+    }
+
+    public Atlas validFloatingLevelRelationBuildingAtlas()
+    {
+        return this.validFloatingLevelRelationBuildingAtlas;
+    }
+
+    public Atlas invalidFloatingLevelRelationBuildingAtlas()
+    {
+        return this.invalidFloatingLevelRelationBuildingAtlas;
     }
 
     public Atlas validBuildingPartsTouchAtlas()
@@ -274,6 +338,16 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     public Atlas invalidBuildingAndPartStackedAtlas()
     {
         return this.invalidBuildingAndPartStackedAtlas;
+    }
+
+    public Atlas validBuildingRelationAndPartStackedAtlas()
+    {
+        return this.validBuildingRelationAndPartStackedAtlas;
+    }
+
+    public Atlas invalidBuildingRelationAndPartStackedAtlas()
+    {
+        return this.invalidBuildingRelationAndPartStackedAtlas;
     }
 
     public Atlas invalidBuildingsStackedAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
@@ -149,6 +149,21 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
                                     "building:part=yes", "height=30", "min_height=17.5" }) })
     private Atlas validBuildingPartsStackedMixedTagsAtlas;
 
+    @TestAtlas(
+            // areas
+            areas = { @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                    @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building:part=yes",
+                            "building:levels=8", "building:min_level=5" }),
+                    @Area(coordinates = { @Loc(value = TEST_3), @Loc(value = TEST_4),
+                            @Loc(value = TEST_6), @Loc(value = TEST_5) }, tags = {
+                                    "building:part=yes", "building:levels=8",
+                                    "building:min_level=5" }),
+                    @Area(coordinates = { @Loc(value = TEST_5), @Loc(value = TEST_6),
+                            @Loc(value = TEST_7), @Loc(value = TEST_8) }, tags = {
+                                    "building:part=yes", "building:levels=8",
+                                    "building:min_level=5" }) })
+    private Atlas invalidBuildingPartsManyFloatAtlas;
+
     public Atlas validBuildingAtlas()
     {
         return this.validBuildingAtlas;
@@ -207,5 +222,10 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     public Atlas validBuildingPartsStackedMixedTagsAtlas()
     {
         return this.validBuildingPartsStackedMixedTagsAtlas;
+    }
+
+    public Atlas invalidBuildingPartsManyFloatAtlas()
+    {
+        return this.invalidBuildingPartsManyFloatAtlas;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
@@ -255,6 +255,32 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     @TestAtlas(
             // areas
             areas = { @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                    @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building:levels=5" }),
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_6), @Loc(value = TEST_5) }, tags = {
+                                    "building:levels=8", "building:min_level=5" }) })
+    private Atlas invalidUntaggedAreasStackedAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = {
+                    @Area(id = "1000000", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2), @Loc(value = TEST_4),
+                            @Loc(value = TEST_3) }, tags = { "building:levels=5" }),
+                    @Area(id = "2000000", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2), @Loc(value = TEST_6),
+                            @Loc(value = TEST_5) }, tags = { "building:levels=8",
+                                    "building:min_level=5" }) },
+            // relation
+            relations = {
+                    @Relation(members = { @Member(id = "1000000", type = "area", role = "outline"),
+                            @Member(id = "2000000", type = "area", role = "part") }, tags = {
+                                    "type=building" }) })
+    private Atlas validUntaggedAreasStackedBuildingRelationAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = { @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                     @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building:part=yes",
                             "building:levels=8", "building:min_level=5" }),
                     @Area(coordinates = { @Loc(value = TEST_3), @Loc(value = TEST_4),
@@ -377,6 +403,16 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     public Atlas invalidBuildingsStackedAtlas()
     {
         return this.invalidBuildingsStackedAtlas;
+    }
+
+    public Atlas invalidUntaggedAreasStackedAtlas()
+    {
+        return this.invalidUntaggedAreasStackedAtlas;
+    }
+
+    public Atlas validUntaggedAreasStackedBuildingRelationAtlas()
+    {
+        return this.validUntaggedAreasStackedBuildingRelationAtlas;
     }
 
     public Atlas invalidBuildingPartsManyFloatAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
@@ -164,6 +164,13 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
                                     "building:min_level=5" }) })
     private Atlas invalidBuildingPartsManyFloatAtlas;
 
+    @TestAtlas(
+            // areas
+            areas = { @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                    @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building:part=yes",
+                            "height=20", "min_height=5" }) })
+    private Atlas invalidBuildingPartSingleAtlas;
+
     public Atlas validBuildingAtlas()
     {
         return this.validBuildingAtlas;
@@ -227,5 +234,10 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     public Atlas invalidBuildingPartsManyFloatAtlas()
     {
         return this.invalidBuildingPartsManyFloatAtlas;
+    }
+
+    public Atlas invalidBuildingPartSingleAtlas()
+    {
+        return this.invalidBuildingPartSingleAtlas;
     }
 }


### PR DESCRIPTION
### Description:

This check flags buildings that are floating in 3D, casting abnormal shadows on the base map when rendered. 
The check looks for Areas or multi-polygon Relations that have a building or building:part tag and a min_height or building:min_level tag > 0. A BFS is used to traverse 3D connected building parts, looking for a path to the ground. If a path is not found all collected parts are flagged. 

### Potential Impact:

No impacts other than having another check to run.

### Unit Test Approach:

A wide array of tests have been used to check many 2D and 3D configuration of building parts, various tag combinations, and the ability to process both Areas and Relations.

### Test Results:

Tests of this check across a variety of countries showed it to work about 98% of the time. 
There were two cases that cause false positives that were left unhandled. The first is when a height or level tag contains a unit indicator (such as "10 ft"). There were only a limited number of these cases, and they would take a relatively high amount of effort to properly handle. The second case is when a multi-polygon relation is tagged as building:part. This is currently used in some complex structures in OSM, but is not part of the standard defined by the wiki. Thus, it was not included as a valid way of defining a building part. 

