### PR TITLE
ShadowDetectionCheck Enhancement: use altitude extractor

### DIFF
--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
@@ -229,4 +229,20 @@ public class ShadowDetectionCheckTest
                 new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
+
+    @Test
+    public void validBuildingPartsTouchHeightMetersTest()
+    {
+        this.verifier.actual(this.setup.validBuildingPartsTouchHeightMetersAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validBuildingPartsTouchHeightFeetInchesTest()
+    {
+        this.verifier.actual(this.setup.validBuildingPartsTouchHeightFeetInchesAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
@@ -307,6 +307,28 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
                             "height=20", "min_height=5" }) })
     private Atlas invalidBuildingPartSingleAtlas;
 
+    @TestAtlas(
+            // areas
+            areas = {
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = {
+                                    "building:part=yes", "height=17.5 m" }),
+                    @Area(coordinates = { @Loc(value = TEST_3), @Loc(value = TEST_4),
+                            @Loc(value = TEST_6), @Loc(value = TEST_5) }, tags = {
+                                    "building:part=yes", "height=28 m", "min_height=3.5 m" }) })
+    private Atlas validBuildingPartsTouchHeightMetersAtlas;
+
+    @TestAtlas(
+            // areas
+            areas = {
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = {
+                                    "building:part=yes", "height=57'5\"" }),
+                    @Area(coordinates = { @Loc(value = TEST_3), @Loc(value = TEST_4),
+                            @Loc(value = TEST_6), @Loc(value = TEST_5) }, tags = {
+                                    "building:part=yes", "height=91'10\"", "min_height=11'6\"" }) })
+    private Atlas validBuildingPartsTouchHeightFeetInchesAtlas;
+
     public Atlas validBuildingAtlas()
     {
         return this.validBuildingAtlas;
@@ -435,5 +457,15 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     public Atlas invalidBuildingPartSingleAtlas()
     {
         return this.invalidBuildingPartSingleAtlas;
+    }
+
+    public Atlas validBuildingPartsTouchHeightMetersAtlas()
+    {
+        return this.validBuildingPartsTouchHeightMetersAtlas;
+    }
+
+    public Atlas validBuildingPartsTouchHeightFeetInchesAtlas()
+    {
+        return this.validBuildingPartsTouchHeightFeetInchesAtlas;
     }
 }


### PR DESCRIPTION
### Description:

This updates ShadowDetectionCheck to use the AltitudeExtractor via the MinHeightTag and HeightTag classes. This allows it to process values from these tags that include units (e.g. `3 m`, `6'3"`). This fixes the related false positive cases mentioned in https://github.com/osmlab/atlas-checks/pull/103.

### Potential Impact:

None

### Unit Test Approach:

Added unit test for tags with meters and feet/inches.

### Test Results:

Ran before and after on SGP and DNK. SGP had no changes and DNK had a loss of 8 cases. This is consistent with what was expected from testing done for https://github.com/osmlab/atlas-checks/pull/103. All lost flags were items that were flagged due to tags with units. 

