### PR TITLE
SingleSegmentMotorwayCheck

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,7 +4,7 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": false
+    "enabled.value.default": true
   },
   "PoolSizeCheck": {
     "surface": {
@@ -321,9 +321,7 @@
       "tags":"highway"
     }
   },
-  "SingleSegmentMotorwayCheck": {
-    "enabled":true
-  },
+  "SingleSegmentMotorwayCheck": {},
   "SinkIslandCheck": {
     "tree.size": 50,
     "minimum.highway.type": "service",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -321,7 +321,14 @@
       "tags":"highway"
     }
   },
-  "SingleSegmentMotorwayCheck": {},
+  "SingleSegmentMotorwayCheck": {
+    "challenge": {
+      "description": "Tasks that identify ways tagged with highway=motorway that are not connected to any ways tagged the same.",
+      "blurb": "Fix disconnected motorways.",
+      "instruction": "Open your favorite editor and check whether the way should be tagged as highway=motorway.",
+      "difficulty": "NORMAL"
+    }
+  },
   "SinkIslandCheck": {
     "tree.size": 50,
     "minimum.highway.type": "service",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,7 +4,7 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": true
+    "enabled.value.default": false
   },
   "PoolSizeCheck": {
     "surface": {
@@ -320,6 +320,9 @@
       },
       "tags":"highway"
     }
+  },
+  "SingleSegmentMotorwayCheck": {
+    "enabled":true
   },
   "SinkIslandCheck": {
     "tree.size": 50,

--- a/docs/checks/singleSegmentMotorwayCheck.md
+++ b/docs/checks/singleSegmentMotorwayCheck.md
@@ -19,7 +19,7 @@ Next the valid objects have their connected edges checked to see if there are an
 If none are found the edge is flagged.
 
 Roundabouts are excluded from this check because they often act more like highway links. 
-There presence cannot be counted on to indicate the continuation of a highway classification. 
+Their presence cannot be counted on to indicate the continuation of a highway classification. 
 
 To learn more about the code, please look at the comments in the source code for the check.  
 [SingleSegmentMotorwayCheck](../../src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SingleSegmentMotorwayCheck.java)

--- a/docs/checks/singleSegmentMotorwayCheck.md
+++ b/docs/checks/singleSegmentMotorwayCheck.md
@@ -1,6 +1,6 @@
 # Single Segment Motorway Check
 
-This check flags Edges that are tagged with highway=motorway and not connected to any other Edges with the same highway tag.
+This check flags Edges that are tagged with highway=motorway and are not connected to any other Edges with the same highway tag.
 
 #### Live Examples
 

--- a/docs/checks/singleSegmentMotorwayCheck.md
+++ b/docs/checks/singleSegmentMotorwayCheck.md
@@ -1,0 +1,25 @@
+# Single Segment Motorway Check
+
+This check flags Edges that are tagged with highway=motorway and not connected to any other Edges with the same highway tag.
+
+#### Live Examples
+
+1. Way [id:568803646](https://www.openstreetmap.org/way/568803646) is tagged as motorway, but is only connected to two motorway_links.
+2. Way [id:154947124](https://www.openstreetmap.org/way/154947124) is tagged as motorway, and it is connected to a trunk. 
+It is also connected to a roundabout tagged as motorway, but this is ignored (see below).
+
+#### Code Review
+
+In [Atlas](https://github.com/osmlab/atlas), OSM elements are represented as Edges, Points, Lines, Nodes, Areas & Relations; in our case, we’re are looking at
+[Edges](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java).
+
+This check first validates object by checking that they are master Edges, tagged as motorways, not roundabouts, and their OSM id has not already been flagged.
+
+Next the valid objects have their connected edges checked to see if there are any tagged with motorway that are not roundabouts.
+If none are found the edge is flagged.
+
+Roundabouts are excluded from this check because they often act more like highway links. 
+There presence cannot be counted on to indicate the continuation of a highway classification. 
+
+To learn more about the code, please look at the comments in the source code for the check.  
+[SingleSegmentMotorwayCheck](../../src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SingleSegmentMotorwayCheck.java)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SingleSegmentMotorwayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SingleSegmentMotorwayCheck.java
@@ -14,7 +14,7 @@ import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
- * This flags {@link Edge}s that are tagged with highway=motorway and not connected to any other
+ * This flags {@link Edge}s that are tagged with highway=motorway and are not connected to any other
  * {@link Edge}s with the same highway tag.
  *
  * @author bbreithaupt
@@ -51,7 +51,8 @@ public class SingleSegmentMotorwayCheck extends BaseCheck<Long>
     public boolean validCheckForObject(final AtlasObject object)
     {
         return object instanceof Edge && ((Edge) object).isMasterEdge()
-                && this.isMotorway((Edge) object) && !this.isFlagged(object.getOsmIdentifier());
+                && this.isMotorwayNotRoundabout((Edge) object)
+                && !this.isFlagged(object.getOsmIdentifier());
     }
 
     /**
@@ -64,7 +65,7 @@ public class SingleSegmentMotorwayCheck extends BaseCheck<Long>
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
-        if (((Edge) object).connectedEdges().stream().noneMatch(this::isMotorway))
+        if (((Edge) object).connectedEdges().stream().noneMatch(this::isMotorwayNotRoundabout))
         {
             this.markAsFlagged(object.getOsmIdentifier());
             return Optional.of(this.createFlag(object,
@@ -81,7 +82,7 @@ public class SingleSegmentMotorwayCheck extends BaseCheck<Long>
      *            {@link Edge}
      * @return {@link boolean}
      */
-    private boolean isMotorway(final Edge edge)
+    private boolean isMotorwayNotRoundabout(final Edge edge)
     {
         return Validators.isOfType(edge, HighwayTag.class, HighwayTag.MOTORWAY)
                 && !JunctionTag.isRoundabout(edge);

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SingleSegmentMotorwayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SingleSegmentMotorwayCheck.java
@@ -15,7 +15,7 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
  * This flags {@link Edge}s that are tagged with highway=motorway and not connected to any other
- * edges with the same highway tag.
+ * {@link Edge}s with the same highway tag.
  *
  * @author bbreithaupt
  */

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SingleSegmentMotorwayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SingleSegmentMotorwayCheck.java
@@ -1,0 +1,95 @@
+package org.openstreetmap.atlas.checks.validation.linear.edges;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.JunctionTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * This flags {@link Edge}s that are tagged with highway=motorway and not connected to any other
+ * edges with the same highway tag.
+ *
+ * @author bbreithaupt
+ */
+public class SingleSegmentMotorwayCheck extends BaseCheck<Long>
+{
+
+    private static final long serialVersionUID = 5874631233752066384L;
+    private static final String SINGLE_SEGMENT_INSTRUCTION = "This way, id:{0,number,#}, is a motorway that is disconnected from any other motorways.";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Collections
+            .singletonList(SINGLE_SEGMENT_INSTRUCTION);
+
+    /**
+     * The default constructor that must be supplied. The Atlas Checks framework will generate the
+     * checks with this constructor, supplying a configuration that can be used to adjust any
+     * parameters that the check uses during operation.
+     *
+     * @param configuration
+     *            the JSON configuration for this check
+     */
+    public SingleSegmentMotorwayCheck(final Configuration configuration)
+    {
+        super(configuration);
+    }
+
+    /**
+     * This function will validate if the supplied atlas object is valid for the check.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return {@code true} if this object should be checked
+     */
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return object instanceof Edge && ((Edge) object).isMasterEdge()
+                && this.isMotorway((Edge) object) && !this.isFlagged(object.getOsmIdentifier());
+    }
+
+    /**
+     * This is the actual function that will check to see whether the object needs to be flagged.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return an optional {@link CheckFlag} object that
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        if (((Edge) object).connectedEdges().stream().noneMatch(this::isMotorway))
+        {
+            this.markAsFlagged(object.getOsmIdentifier());
+            return Optional.of(this.createFlag(object,
+                    this.getLocalizedInstruction(0, object.getOsmIdentifier())));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Checks if an {@link Edge} is tagged with highway=motorway. Roundabouts are excluded, as they
+     * act more like motorway_links than motorway segments in most cases found.
+     *
+     * @param edge
+     *            {@link Edge}
+     * @return {@link boolean}
+     */
+    private boolean isMotorway(final Edge edge)
+    {
+        return Validators.isOfType(edge, HighwayTag.class, HighwayTag.MOTORWAY)
+                && !JunctionTag.isRoundabout(edge);
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SingleSegmentMotorwayCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SingleSegmentMotorwayCheckTest.java
@@ -1,0 +1,54 @@
+package org.openstreetmap.atlas.checks.validation.linear.edges;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * Unit tests for {@link SingleSegmentMotorwayCheck}.
+ *
+ * @author bbreithaupt
+ */
+public class SingleSegmentMotorwayCheckTest
+{
+    @Rule
+    public SingleSegmentMotorwayCheckTestRule setup = new SingleSegmentMotorwayCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void validMotorwaySegmentsTest()
+    {
+        this.verifier.actual(this.setup.validMotorwaySegmentsAtlas(),
+                new SingleSegmentMotorwayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void invalidPrimaryMotorwayPrimarySegmentTest()
+    {
+        this.verifier.actual(this.setup.invalidPrimaryMotorwayPrimarySegmentAtlas(),
+                new SingleSegmentMotorwayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void invalidMotorwaySegmentOneConnectionTest()
+    {
+        this.verifier.actual(this.setup.invalidMotorwaySegmentOneConnectionAtlas(),
+                new SingleSegmentMotorwayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void invalidMotorwaySegmentOneConnectionRoundaboutTest()
+    {
+        this.verifier.actual(this.setup.invalidMotorwaySegmentOneConnectionRoundaboutAtlas(),
+                new SingleSegmentMotorwayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SingleSegmentMotorwayCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SingleSegmentMotorwayCheckTestRule.java
@@ -1,0 +1,108 @@
+package org.openstreetmap.atlas.checks.validation.linear.edges;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * Unit test rules for {@link SingleSegmentMotorwayCheck}.
+ *
+ * @author bbreithaupt
+ */
+public class SingleSegmentMotorwayCheckTestRule extends CoreTestRule
+{
+    private static final String TEST_1 = "48.1033298347647,-122.794643805939";
+    private static final String TEST_2 = "48.1034825739679,-122.796334374533";
+    private static final String TEST_3 = "48.1033862819144,-122.798144277382";
+    private static final String TEST_4 = "48.1032534649929,-122.79873100413";
+    private static final String TEST_5 = "48.1034327677559,-122.798775754475";
+    private static final String TEST_6 = "48.1032899896805,-122.79916856306";
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_4)) },
+            // edges
+            edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
+                            "highway=motorway" }),
+                    @Edge(coordinates = { @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
+                            "highway=motorway" }),
+                    @Edge(coordinates = { @Loc(value = TEST_3), @Loc(value = TEST_4) }, tags = {
+                            "highway=motorway" }) })
+    private Atlas validMotorwaySegmentsAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_4)) },
+            // edges
+            edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
+                            "highway=primary" }),
+                    @Edge(coordinates = { @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
+                            "highway=motorway" }),
+                    @Edge(coordinates = { @Loc(value = TEST_3), @Loc(value = TEST_4) }, tags = {
+                            "highway=primary" }) })
+    private Atlas invalidPrimaryMotorwayPrimarySegmentAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3)) },
+            // edges
+            edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
+                            "highway=primary" }),
+                    @Edge(coordinates = { @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
+                            "highway=motorway" }) })
+    private Atlas invalidMotorwaySegmentOneConnectionAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_4)),
+                    @Node(coordinates = @Loc(value = TEST_5)),
+                    @Node(coordinates = @Loc(value = TEST_6)) },
+            // edges
+            edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
+                            "highway=primary" }),
+                    @Edge(coordinates = { @Loc(value = TEST_3), @Loc(value = TEST_5) }, tags = {
+                            "highway=motorway", "oneway=yes" }),
+                    @Edge(coordinates = { @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = {
+                            "highway=primary", "oneway=yes" }),
+                    @Edge(coordinates = { @Loc(value = TEST_4), @Loc(value = TEST_5),
+                            @Loc(value = TEST_6), @Loc(value = TEST_4) }, tags = {
+                                    "highway=motorway", "oneway=yes", "junction=roundabout" }), })
+    private Atlas invalidMotorwaySegmentOneConnectionRoundaboutAtlas;
+
+    public Atlas validMotorwaySegmentsAtlas()
+    {
+        return this.validMotorwaySegmentsAtlas;
+    }
+
+    public Atlas invalidPrimaryMotorwayPrimarySegmentAtlas()
+    {
+        return this.invalidPrimaryMotorwayPrimarySegmentAtlas;
+    }
+
+    public Atlas invalidMotorwaySegmentOneConnectionAtlas()
+    {
+        return this.invalidMotorwaySegmentOneConnectionAtlas;
+    }
+
+    public Atlas invalidMotorwaySegmentOneConnectionRoundaboutAtlas()
+    {
+        return this.invalidMotorwaySegmentOneConnectionRoundaboutAtlas;
+    }
+}


### PR DESCRIPTION
### Description:

This check flags Edges that are tagged with highway=motorway and not connected to any other Edges with the same highway tag. A road of this classification should be connected to a network of Edges with that classification. Roundabouts are ignored, as they have been found to act more like links, and do not consistently indicate continuation of a highway classification. 

**OSM Example:**
1. Way [id:568803646](https://www.openstreetmap.org/way/568803646) is tagged as motorway, but is only connected to two motorway_links.
2. Way [id:154947124](https://www.openstreetmap.org/way/154947124) is tagged as motorway, and it is connected to a trunk. It is also connected to a roundabout tagged as motorway, but this is ignored (see below).

### Potential Impact:

Adds a check.

### Unit Test Approach:

Unit tests check that Edges are flagged in a number of different connection scenarios. The test include both valid and invalid cases.

### Test Results:

The check was run on MAR, UGA, RWA, and CHL. 8 flags were produced and all were valid. Based on research prior to development this flag count is as expected. 

