### PR TITLE
SignPostCheck Overhaul

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -321,6 +321,18 @@
       "tags":"highway"
     }
   },
+  "SignPostCheck": {
+    "ramp.filter":"highway->motorway_link,trunk_link",
+    "destination_tag.filter":"destination->*|destination:ref->*|destination:street->*",
+    "challenge": {
+      "description": "Tasks contain nodes where sign post tagging could be missing.  In particular it looks for motorway and trunk ways which have a link edge exiting them.  A task is generated if either the connecting node is missing the motorway_junction tag or the exiting segment is missing the destination tag.",
+      "blurb": "Missing sign post tags",
+      "instruction": "Either add the missing motorway_junction tag to the identified node and / or the destination tag to the exiting link segment.",
+      "difficulty": "NORMAL",
+      "defaultPriority": "MEDIUM",
+      "tags":"highway"
+    }
+  },
   "SingleSegmentMotorwayCheck": {
     "challenge": {
       "description": "Tasks that identify ways tagged with highway=motorway that are not connected to any ways tagged the same.",
@@ -374,27 +386,6 @@
         "condition":"OR",
         "rules":["highway=primary","highway=primary_link","highway=secondary","highway=secondary_link"]
       },
-      "tags":"highway"
-    }
-  },
-  "SignPostCheck": {
-    "linkLength": {
-      "minimum.meters": 50.0
-    },
-    "ramp":
-    {
-      "max.edges":10,
-      "filter":"highway->motorway_link,trunk_link"
-    },
-    "source.filter":"highway->motorway,trunk",
-    "destination_tag.filter":"destination->*|destination:ref->*|destination:street->*",
-    "arterial.minimum":"RESIDENTIAL",
-    "challenge": {
-      "description": "Tasks contain nodes where sign post tagging could be missing.  In particular it looks for motorway and trunk ways which have a link edge exiting them.  A task is generated if either the connecting node is missing the motorway_junction tag or the exiting segment is missing the destination tag.",
-      "blurb": "Missing sign post tags",
-      "instruction": "Either add the missing motorway_junction tag to the identified node and / or the destination tag to the exiting link segment.",
-      "difficulty": "NORMAL",
-      "defaultPriority": "MEDIUM",
       "tags":"highway"
     }
   },

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -322,8 +322,11 @@
     }
   },
   "SignPostCheck": {
+    "linkLength.minimum.meters": 50.0,
+    "source.filter": "highway->motorway,trunk",
     "ramp.filter":"highway->motorway_link,trunk_link",
-    "destination_tag.filter":"destination->*|destination:ref->*|destination:street->*",
+    "destination_tag.filter":"destination->*|destination:ref->*|destination:street->*|destination:backward->*|destination:forwards->*",
+    "link.branch.check": true,
     "challenge": {
       "description": "Tasks contain nodes where sign post tagging could be missing.  In particular it looks for motorway and trunk ways which have a link edge exiting them.  A task is generated if either the connecting node is missing the motorway_junction tag or the exiting segment is missing the destination tag.",
       "blurb": "Missing sign post tags",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
@@ -125,7 +125,7 @@ public class SignPostCheck extends BaseCheck<String>
         final Set<Node> junctionNodes = new HashSet<>();
         boolean checkDestination = false;
 
-        // Get in edes from edge and its reverse, if it has one
+        // Get in edges from edge and its reverse, if it has one
         final Set<Edge> inEdges = new HashSet<>(edge.inEdges());
         edge.reversed().ifPresent(reverseEdge -> inEdges.addAll(reverseEdge.inEdges()));
 
@@ -190,7 +190,7 @@ public class SignPostCheck extends BaseCheck<String>
 
     /**
      * Checks if an {@link Edge} has 2 or more out Edges of the same highway classification as
-     * itself, excluding its reverse edge.
+     * itself, excluding its reverseå edge.
      *
      * @param edge
      *            {@link Edge} to check

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
@@ -99,7 +99,7 @@ public class SignPostCheck extends BaseCheck<String>
     public boolean validCheckForObject(final AtlasObject object)
     {
         return TypePredicates.IS_EDGE.test(object) && ((Edge) object).isMasterEdge()
-                && !this.isFlagged(this.getTaskIdentifier(object))
+                && !this.isFlagged(String.valueOf(object.getOsmIdentifier()))
                 && this.rampEdgeFilter.test(object) && ((Edge) object).highwayTag().isLink()
                 && ((Edge) object).length().isGreaterThan(this.minimumLinkLength);
     }
@@ -116,7 +116,7 @@ public class SignPostCheck extends BaseCheck<String>
     {
         final Edge edge = (Edge) object;
         final HighwayTag highwayTag = edge.highwayTag();
-        final CheckFlag flag = new CheckFlag(this.getTaskIdentifier(object));
+        final CheckFlag flag = new CheckFlag(String.valueOf(object.getOsmIdentifier()));
         final Set<Node> junctionNodes = new HashSet<>();
         boolean checkDestination = false;
 
@@ -161,7 +161,7 @@ public class SignPostCheck extends BaseCheck<String>
         // Return the flag if it has any flagged objects in it
         if (!flag.getFlaggedObjects().isEmpty())
         {
-            this.markAsFlagged(this.getTaskIdentifier(object));
+            this.markAsFlagged(String.valueOf(object.getOsmIdentifier()));
             return Optional.of(flag);
         }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
@@ -1,24 +1,20 @@
 package org.openstreetmap.atlas.checks.validation.linear.edges;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
-import org.apache.directory.api.util.Strings;
 import org.openstreetmap.atlas.checks.atlas.predicates.TypePredicates;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
-import org.openstreetmap.atlas.tags.DestinationTag;
 import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.RelationTypeTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.tags.filters.TaggableFilter;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
-import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 /**
  * This check is used to help identify segments that are missing the proper tagging for sign posts.
@@ -33,36 +29,21 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
  *
  * @author ericgodwin
  * @author mkalender
+ * @author bbreithaupt
  */
 public class SignPostCheck extends BaseCheck<String>
 {
     private static final long serialVersionUID = 8042255121118115024L;
 
     // Instruction
-    private static final String NODE_INSTRUCTION = "Junction node {0,number,#} is missing the following tags: {1}.";
-    private static final String EDGE_INSTRUCTION = "Way {0,number,#} ({1}) is missing the following tags: {2}.";
-    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(NODE_INSTRUCTION,
-            EDGE_INSTRUCTION);
-    private static final String OFF_RAMP_KEY = "off-ramp";
-    private static final String ON_RAMP_KEY = "on-ramp";
+    private static final String JUNCTION_NODE_INSTRUCTION = "Junction node {0,number,#} is missing a motorway_junction tag.";
+    private static final String DESTINATION_TAG_INSTRUCTION = "Way {0,number,#} is missing a destination tag.";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
+            .asList(JUNCTION_NODE_INSTRUCTION, DESTINATION_TAG_INSTRUCTION);
 
     // Default values for configurable settings
-    private static final double DISTANCE_MINIMUM_METERS_DEFAULT = 50;
-    private static final String SOURCE_EDGE_FILTER_DEFAULT = "highway->motorway,trunk";
     private static final String RAMP_FILTER_DEFAULT = "highway->motorway_link,trunk_link";
     private static final String DESTINATION_TAG_FILTER_DEFAULT = "destination->*|destination:ref->*|destination:street->*";
-    private static final String ARTERIAL_MINIMUM_DEFAULT = HighwayTag.RESIDENTIAL.toString();
-
-    // Maximum number of hops while collecting ramp edges
-    private static final long MAX_EDGE_COUNT_FOR_RAMP_DEFAULT = 5;
-
-    private final long maxEdgeCountForRamp;
-
-    // The minimum link length to examine.
-    private final Distance minimumLinkLength;
-
-    // A filter to filter source edges for flagging
-    private final TaggableFilter sourceEdgeFilter;
 
     // A filter to filter ramp edges
     private final TaggableFilter rampEdgeFilter;
@@ -70,11 +51,8 @@ public class SignPostCheck extends BaseCheck<String>
     // A filter for the variations of the destination tag
     private final TaggableFilter destinationTagFilter;
 
-    // A tag to differentiate ramps from roads with the same classification
-    private final String rampDifferentiatorTag;
-
-    // The minimum highway tag for an arterial road
-    private final HighwayTag arterialMinimum;
+    // Whether to check link branches for destination tags.
+    private final boolean checkLinkBranches;
 
     /**
      * The default constructor that must be supplied. The Atlas Checks framework will generate the
@@ -88,21 +66,11 @@ public class SignPostCheck extends BaseCheck<String>
     {
         super(configuration);
 
-        this.maxEdgeCountForRamp = configurationValue(configuration, "ramp.max.edges",
-                MAX_EDGE_COUNT_FOR_RAMP_DEFAULT);
-        this.minimumLinkLength = configurationValue(configuration, "linkLength.minimum.meters",
-                DISTANCE_MINIMUM_METERS_DEFAULT, Distance::meters);
-        this.sourceEdgeFilter = configurationValue(configuration, "source.filter",
-                SOURCE_EDGE_FILTER_DEFAULT, value -> TaggableFilter.forDefinition(value));
         this.rampEdgeFilter = configurationValue(configuration, "ramp.filter", RAMP_FILTER_DEFAULT,
-                value -> TaggableFilter.forDefinition(value));
+                TaggableFilter::forDefinition);
         this.destinationTagFilter = configurationValue(configuration, "destination_tag.filter",
-                DESTINATION_TAG_FILTER_DEFAULT, value -> TaggableFilter.forDefinition(value));
-        this.rampDifferentiatorTag = configurationValue(configuration, "ramp.differentiator.tag",
-                null);
-        this.arterialMinimum = Enum.valueOf(HighwayTag.class,
-                configurationValue(configuration, "arterial.minimum", ARTERIAL_MINIMUM_DEFAULT)
-                        .toUpperCase());
+                DESTINATION_TAG_FILTER_DEFAULT, TaggableFilter::forDefinition);
+        this.checkLinkBranches = configurationValue(configuration, "link.branch.check", true);
     }
 
     /**
@@ -115,7 +83,8 @@ public class SignPostCheck extends BaseCheck<String>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return TypePredicates.IS_EDGE.test(object) && this.sourceEdgeFilter.test(object);
+        return TypePredicates.IS_EDGE.test(object) && ((Edge) object).isMasterEdge()
+                && this.rampEdgeFilter.test(object) && ((Edge) object).highwayTag().isLink();
     }
 
     /**
@@ -132,51 +101,47 @@ public class SignPostCheck extends BaseCheck<String>
         final HighwayTag highwayTag = edge.highwayTag();
         final CheckFlag flag = new CheckFlag(this.getTaskIdentifier(object));
 
-        // First find off ramps
-        edge.end().outEdges().stream()
-                .filter(connectedEdge -> isPossiblyRamp(edge, highwayTag, connectedEdge))
-                .forEach(outEdge ->
-                {
-                    // Check to see if start node is missing junction tag
-                    final Node start = outEdge.start();
-                    if (!Validators.isOfType(start, HighwayTag.class, HighwayTag.MOTORWAY_JUNCTION))
-                    {
-                        flag.addInstruction(this.getLocalizedInstruction(0,
-                                start.getOsmIdentifier(), String.format("%s=%s", HighwayTag.KEY,
-                                        HighwayTag.MOTORWAY_JUNCTION.getTagValue())));
-                        flag.addObject(start);
-                    }
+        final HighwayTag targetType = highwayTag.getHighwayFromLink().get();
 
-                    // Check if edge is missing destination tag
-                    if (!destinationTagFilter.test(outEdge))
-                    {
-                        flag.addInstruction(this.getLocalizedInstruction(1,
-                                outEdge.getOsmIdentifier(), OFF_RAMP_KEY, DestinationTag.KEY));
-                        flag.addObject(outEdge);
-                    }
-                });
+        boolean checkDestination = false;
+        boolean checkJunctionNode = false;
 
-        // Then repeat the work for on ramps
-        edge.start().inEdges().stream()
-                .filter(connectedEdge -> isPossiblyRamp(edge, highwayTag, connectedEdge))
-                .forEach(inEdge ->
-                {
-                    // Find the source of in-ramp
-                    final List<Edge> rampEdgeList = findFirstRampEdge(inEdge,
-                            this.maxEdgeCountForRamp);
+        for (final Edge inEdge : edge.inEdges())
+        {
+            final HighwayTag inHighwayTag = inEdge.highwayTag();
+            if (inHighwayTag.equals(targetType))
+            {
+                checkDestination = true;
+                checkJunctionNode = true;
+                break;
+            }
+            else if (!inHighwayTag.equals(highwayTag))
+            {
+                checkDestination = true;
+            }
+            else if (this.checkLinkBranches && inEdge.outEdges().stream().anyMatch(
+                    outEdge -> outEdge.highwayTag().equals(highwayTag) && !outEdge.equals(edge)))
+            {
+                checkDestination = true;
+            }
+        }
 
-                    for (final Edge rampEdge : rampEdgeList)
-                    {
+        // Check to see if start node is missing junction tag
+        final Node start = edge.start();
+        if (checkJunctionNode
+                && !Validators.isOfType(start, HighwayTag.class, HighwayTag.MOTORWAY_JUNCTION))
+        {
+            flag.addInstruction(this.getLocalizedInstruction(0, start.getOsmIdentifier()));
+            flag.addObject(start);
+        }
 
-                        // Check if edge is missing destination tag
-                        if (!destinationTagFilter.test(rampEdge))
-                        {
-                            flag.addInstruction(this.getLocalizedInstruction(1,
-                                    rampEdge.getOsmIdentifier(), ON_RAMP_KEY, DestinationTag.KEY));
-                            flag.addObject(rampEdge);
-                        }
-                    }
-                });
+        if (checkDestination && !destinationTagFilter.test(edge)
+                && edge.relations().stream().noneMatch(relation -> Validators.isOfType(relation,
+                        RelationTypeTag.class, RelationTypeTag.DESTINATION_SIGN)))
+        {
+            flag.addInstruction(this.getLocalizedInstruction(1, edge.getOsmIdentifier()));
+            flag.addObject(edge);
+        }
 
         // Return the flag if it has any flagged objects in it
         if (!flag.getFlaggedObjects().isEmpty())
@@ -191,97 +156,5 @@ public class SignPostCheck extends BaseCheck<String>
     protected List<String> getFallbackInstructions()
     {
         return FALLBACK_INSTRUCTIONS;
-    }
-
-    /**
-     * Given a final {@link Edge}, hops back and finds the first edge that was forming the ramp.
-     *
-     * @param finalEdge
-     *            {@link Edge} that is the last/final piece of the ramp
-     * @return {@link Edge} that possibly is the first {@link Edge} forming the ramp
-     */
-    private List<Edge> findFirstRampEdge(final Edge finalEdge, final long maxEdgeCount)
-    {
-        // Go back and collect edges
-        final List<Edge> endEdges = new ArrayList<>();
-        if (maxEdgeCount > 0)
-        {
-            // Collect in edges and make sure the list is not empty
-            final Set<Edge> inEdges = finalEdge.inEdges();
-            if (!inEdges.isEmpty())
-            {
-                // Check each inEdge
-                for (final Edge nextEdge : inEdges)
-                {
-                    // See if it is connected to a source edge
-                    if (this.sourceEdgeFilter.test(nextEdge))
-                    {
-                        endEdges.clear();
-                        return endEdges;
-                    }
-                    // See if it is an arterial
-                    if (!this.rampEdgeFilter.test(nextEdge) && HighwayTag.highwayTag(nextEdge)
-                            .orElse(HighwayTag.NO).isMoreImportantThanOrEqualTo(arterialMinimum))
-                    {
-                        endEdges.clear();
-                        endEdges.add(finalEdge);
-                        return endEdges;
-                    }
-                    // Recurse through inEdges if this edge is not the other side of a bidirectional
-                    // way
-                    else if (nextEdge.highwayTag().isIdenticalClassification(finalEdge.highwayTag())
-                            && finalEdge.getMasterEdgeIdentifier() != nextEdge
-                                    .getMasterEdgeIdentifier())
-                    {
-                        endEdges.addAll(findFirstRampEdge(nextEdge, maxEdgeCount - 1));
-                    }
-                }
-                return endEdges;
-            }
-        }
-        endEdges.clear();
-        endEdges.add(finalEdge);
-        return endEdges;
-    }
-
-    /**
-     * Returns if given a connected {@link Edge} is possibly a ramp entering or leaving source
-     * {@link Edge}.
-     *
-     * @param sourceEdge
-     *            Source {@link Edge}
-     * @param sourceHighwayTag
-     *            {@link HighwayTag} of the source {@link Edge}
-     * @param connectedEdge
-     *            Connected {@link Edge} to source {@link Edge}
-     * @return true if connected {@link Edge} is a ramp
-     */
-    private boolean isPossiblyRamp(final Edge sourceEdge, final HighwayTag sourceHighwayTag,
-            final Edge connectedEdge)
-    {
-        // Ignore if edge is failing to pass ramp filter and also ignore if it is short
-        if (!this.rampEdgeFilter.test(connectedEdge)
-                || !connectedEdge.length().isGreaterThan(this.minimumLinkLength))
-        {
-            return false;
-        }
-
-        // Different classification is a good indication for a ramp
-        if (!sourceHighwayTag.isIdenticalClassification(connectedEdge.highwayTag()))
-        {
-            return true;
-        }
-
-        // If ramp differentiator tag is supplied, then use it to differentiate same classification
-        // edges
-        if (this.rampDifferentiatorTag == null)
-        {
-            return true;
-        }
-
-        // Look for certain tag differences if edges have same highway tag
-        final String sourceTag = sourceEdge.tag(this.rampDifferentiatorTag);
-        final String rampTag = connectedEdge.tag(this.rampDifferentiatorTag);
-        return !(sourceTag == null && rampTag == null || Strings.equals(sourceTag, rampTag));
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
@@ -82,7 +82,7 @@ public class SignPostCheck extends BaseCheck<String>
         this.minimumLinkLength = configurationValue(configuration, "linkLength.minimum.meters",
                 DISTANCE_MINIMUM_METERS_DEFAULT, Distance::meters);
         this.sourceEdgeFilter = configurationValue(configuration, "source.filter",
-                SOURCE_EDGE_FILTER_DEFAULT, value -> TaggableFilter.forDefinition(value));
+                SOURCE_EDGE_FILTER_DEFAULT, TaggableFilter::forDefinition);
         this.rampEdgeFilter = configurationValue(configuration, "ramp.filter", RAMP_FILTER_DEFAULT,
                 TaggableFilter::forDefinition);
         this.destinationTagFilter = configurationValue(configuration, "destination_tag.filter",
@@ -190,7 +190,7 @@ public class SignPostCheck extends BaseCheck<String>
 
     /**
      * Checks if an {@link Edge} has 2 or more out Edges of the same highway classification as
-     * itself, excluding its reverseå edge.
+     * itself, excluding its reverse edge.
      *
      * @param edge
      *            {@link Edge} to check

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheckTest.java
@@ -14,19 +14,16 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
  * Tests for {@link SignPostCheck}
  *
  * @author mkalender
+ * @author bbreithaupt
  */
 public class SignPostCheckTest
 {
     private static SignPostCheck CHECK = new SignPostCheck(
-            ConfigurationResolver.inlineConfiguration("{"
-                    + "\"SignPostCheck.source.filter\": \"highway->motorway,trunk,primary|motorroad->yes\", "
-                    + "\"SignPostCheck.ramp.filter\": \"highway->motorway_link,trunk_link,primary,primary_link&motorroad->!\","
-                    + "\"SignPostCheck.ramp.differentiator.tag\": \"diff\","
-                    + "\"SignPostCheck.ramp.angle.difference.degrees\": 90.0" + "}"));
+            ConfigurationResolver.emptyConfiguration());
 
     private static SignPostCheck CHECK2 = new SignPostCheck(
             ConfigurationResolver.inlineConfiguration(
-                    "{\"SignPostCheck.source.filter\": \"highway->motorway,trunk\", \"SignPostCheck.ramp.filter\": \"highway->motorway_link,trunk_link\"}"));
+                    "{\"SignPostCheck.source.filter\":\"highway->motorway,trunk,primary\", \"SignPostCheck.ramp.filter\":\"highway->motorway_link,trunk_link,primary_link\"}"));
 
     @Rule
     public SignPostCheckTestRule setup = new SignPostCheckTestRule();
@@ -48,25 +45,16 @@ public class SignPostCheckTest
     }
 
     @Test
-    public void motorroadPrimaryLinkMissingJunctionAndDestinationAtlas()
+    public void motorroadPrimaryLinkMissingJunctionAndDestinationTest()
     {
         this.verifier.actual(this.setup.motorroadPrimaryLinkMissingJunctionAndDestinationAtlas(),
-                CHECK);
+                CHECK2);
         this.verifier.verifyExpectedSize(1);
         this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
-    public void motorroadPrimaryMissingJunctionAndDestinationAtlas()
-    {
-        this.verifier.actual(this.setup.motorroadPrimaryMissingJunctionAndDestinationAtlas(),
-                CHECK);
-        this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, 2, true, true));
-    }
-
-    @Test
-    public void motorwayMotorwayLinkMissingJunctionAndDestinationAtlas()
+    public void motorwayMotorwayLinkMissingJunctionAndDestinationTest()
     {
         this.verifier.actual(this.setup.motorwayMotorwayLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
@@ -75,7 +63,7 @@ public class SignPostCheckTest
     }
 
     @Test
-    public void motorwayMotorwayLinkWithJunctionAndDestinationAtlas()
+    public void motorwayMotorwayLinkWithJunctionAndDestinationTest()
     {
         this.verifier.actual(this.setup.motorwayMotorwayLinkWithJunctionAndDestinationAtlas(),
                 CHECK);
@@ -83,7 +71,7 @@ public class SignPostCheckTest
     }
 
     @Test
-    public void motorwayMotorwayLinkWithJunctionAndDestinationRefAtlas()
+    public void motorwayMotorwayLinkWithJunctionAndDestinationRefTest()
     {
         this.verifier.actual(this.setup.motorwayMotorwayLinkWithJunctionAndDestinationRefAtlas(),
                 CHECK);
@@ -91,25 +79,25 @@ public class SignPostCheckTest
     }
 
     @Test
-    public void motorwayMultipleLinksMissingJunctionAndDestinationAtlas()
+    public void motorwayMultipleLinksMissingJunctionAndDestinationTest()
     {
         this.verifier.actual(this.setup.motorwayMultipleLinksMissingJunctionAndDestinationAtlas(),
                 CHECK);
-        this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, 3, true, true));
+        this.verifier.verifyExpectedSize(2);
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
-    public void motorwayPrimaryLinkMissingJunctionAndDestinationAtlas()
+    public void motorwayPrimaryLinkMissingJunctionAndDestinationTest()
     {
         this.verifier.actual(this.setup.motorwayPrimaryLinkMissingJunctionAndDestinationAtlas(),
-                CHECK);
+                CHECK2);
         this.verifier.verifyExpectedSize(1);
         this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
-    public void motorwayShortMotorwayLinkMissingJunctionAndDestinationAtlas()
+    public void motorwayShortMotorwayLinkMissingJunctionAndDestinationTest()
     {
         this.verifier.actual(
                 this.setup.motorwayShortMotorwayLinkMissingJunctionAndDestinationAtlas(), CHECK);
@@ -117,7 +105,7 @@ public class SignPostCheckTest
     }
 
     @Test
-    public void motorwayShortTrunkLinkMissingJunctionAndDestinationAtlas()
+    public void motorwayShortTrunkLinkMissingJunctionAndDestinationTest()
     {
         this.verifier.actual(this.setup.motorwayShortTrunkLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
@@ -125,7 +113,7 @@ public class SignPostCheckTest
     }
 
     @Test
-    public void motorwayTrunkLinkMissingJunctionAndDestinationAtlas()
+    public void motorwayTrunkLinkMissingJunctionAndDestinationTest()
     {
         this.verifier.actual(this.setup.motorwayTrunkLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
@@ -134,7 +122,7 @@ public class SignPostCheckTest
     }
 
     @Test
-    public void motorwayTrunkLinkWithDestinationAtlas()
+    public void motorwayTrunkLinkWithDestinationTest()
     {
         this.verifier.actual(this.setup.motorwayTrunkLinkWithDestinationAtlas(), CHECK);
         this.verifier.verifyExpectedSize(1);
@@ -142,25 +130,25 @@ public class SignPostCheckTest
     }
 
     @Test
-    public void primaryMotorwayLinkMissingJunctionAndDestinationAtlas()
+    public void primaryMotorwayLinkMissingJunctionAndDestinationTest()
     {
         this.verifier.actual(this.setup.primaryMotorwayLinkMissingJunctionAndDestinationAtlas(),
-                CHECK);
+                CHECK2);
         this.verifier.verifyExpectedSize(1);
         this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
-    public void primaryTrunkLinkMissingJunctionAndDestinationAtlas()
+    public void primaryTrunkLinkMissingJunctionAndDestinationTest()
     {
         this.verifier.actual(this.setup.primaryTrunkLinkMissingJunctionAndDestinationAtlas(),
-                CHECK);
+                CHECK2);
         this.verifier.verifyExpectedSize(1);
         this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
-    public void trunkMotorwayLinkMissingJunctionAndDestinationAtlas()
+    public void trunkMotorwayLinkMissingJunctionAndDestinationTest()
     {
         this.verifier.actual(this.setup.trunkMotorwayLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
@@ -169,7 +157,7 @@ public class SignPostCheckTest
     }
 
     @Test
-    public void trunkMotorwayLinkWithJunctionAtlas()
+    public void trunkMotorwayLinkWithJunctionTest()
     {
         this.verifier.actual(this.setup.trunkMotorwayLinkWithJunctionAtlas(), CHECK);
         this.verifier.verifyExpectedSize(1);
@@ -177,7 +165,7 @@ public class SignPostCheckTest
     }
 
     @Test
-    public void trunkShortMotorwayLinkMissingJunctionAndDestinationAtlas()
+    public void trunkShortMotorwayLinkMissingJunctionAndDestinationTest()
     {
         this.verifier.actual(this.setup.trunkShortMotorwayLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
@@ -185,7 +173,7 @@ public class SignPostCheckTest
     }
 
     @Test
-    public void trunkShortTrunkLinkMissingJunctionAndDestinationAtlas()
+    public void trunkShortTrunkLinkMissingJunctionAndDestinationTest()
     {
         this.verifier.actual(this.setup.trunkShortTrunkLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
@@ -193,7 +181,7 @@ public class SignPostCheckTest
     }
 
     @Test
-    public void trunkTrunkLinkMissingJunctionAndDestinationAtlas()
+    public void trunkTrunkLinkMissingJunctionAndDestinationTest()
     {
         this.verifier.actual(this.setup.trunkTrunkLinkMissingJunctionAndDestinationAtlas(), CHECK);
         this.verifier.verifyExpectedSize(1);
@@ -201,7 +189,7 @@ public class SignPostCheckTest
     }
 
     @Test
-    public void unclassifiedPrimaryLinkMissingJunctionAndDestinationAtlas()
+    public void unclassifiedPrimaryLinkMissingJunctionAndDestinationTest()
     {
         this.verifier.actual(this.setup.unclassifiedPrimaryLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
@@ -209,20 +197,40 @@ public class SignPostCheckTest
     }
 
     @Test
-    public void motorwayMotorwayLinkBranchMissingDestinationAtlas()
+    public void motorwayMotorwayLinkBranchMissingDestinationTest()
     {
-        this.verifier.actual(this.setup.motorwayMotorwayLinkBranchMissingDestinationAtlas(),
-                CHECK2);
-        this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, 2, true, false));
+        this.verifier.actual(this.setup.motorwayMotorwayLinkBranchMissingDestinationAtlas(), CHECK);
+        this.verifier.verifyExpectedSize(2);
+        this.verifier.verify(flag -> verify(flag, 1, true, false));
     }
 
     @Test
-    public void motorwayMotorwayLinkTwoWayBranchMissingDestinationAtlas()
+    public void motorwayMotorwayLinkTwoWayBranchMissingDestinationNoBranchCheckAtlas()
     {
         this.verifier.actual(this.setup.motorwayMotorwayLinkTwoWayBranchMissingDestinationAtlas(),
-                CHECK2);
+                new SignPostCheck(ConfigurationResolver
+                        .inlineConfiguration("{\"SignPostCheck.link.branch.check\":false}")));
         this.verifier.verifyExpectedSize(1);
         this.verifier.verify(flag -> verify(flag, 1, true, false));
+    }
+
+    @Test
+    public void motorwayMotorwayLinkTwoWayBranchMissingDestinationRelationTest()
+    {
+        this.verifier.actual(
+                this.setup.motorwayMotorwayLinkTwoWayBranchMissingDestinationRelationAtlas(),
+                CHECK);
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> verify(flag, 1, true, false));
+    }
+
+    @Test
+    public void twoWayTrunksUTurnMissingJunctionAndDestinationTest()
+    {
+        this.verifier.actual(this.setup.twoWayTrunksUTurnMissingJunctionAndDestinationAtlas(),
+                new SignPostCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"SignPostCheck.linkLength.minimum.meters\":10.0}")));
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> verify(flag, 3, true, true));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheckTestRule.java
@@ -418,21 +418,25 @@ public class SignPostCheckTestRule extends CoreTestRule
                     @Node(coordinates = @Loc(value = LINK2_1)) },
             // edges
             edges = {
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_5), @Loc(value = HIGHWAY_4),
+                    @Edge(id = "1000000", coordinates = { @Loc(value = HIGHWAY_5),
+                            @Loc(value = HIGHWAY_4),
                             @Loc(value = HIGHWAY_3) }, tags = { "highway=motorway" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_2),
+                    @Edge(id = "2000000", coordinates = { @Loc(value = HIGHWAY_3),
+                            @Loc(value = HIGHWAY_2),
                             @Loc(value = HIGHWAY_1) }, tags = { "highway=motorway" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY2_3),
+                    @Edge(id = "3000000", coordinates = { @Loc(value = HIGHWAY2_3),
                             @Loc(value = HIGHWAY2_2) }, tags = { "highway=primary" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY2_2), @Loc(value = LINK_4) }, tags = {
-                            "highway=primary" }),
-                    @Edge(coordinates = { @Loc(value = LINK_4), @Loc(value = HIGHWAY2_1) }, tags = {
-                            "highway=primary" }),
-                    @Edge(coordinates = { @Loc(value = LINK_2), @Loc(value = HIGHWAY_3) }, tags = {
-                            "highway=motorway_link" }),
-                    @Edge(coordinates = { @Loc(value = LINK_4), @Loc(value = LINK_3),
+                    @Edge(id = "4000000", coordinates = { @Loc(value = HIGHWAY2_2),
+                            @Loc(value = LINK_4) }, tags = { "highway=primary" }),
+                    @Edge(id = "5000000", coordinates = { @Loc(value = LINK_4),
+                            @Loc(value = HIGHWAY2_1) }, tags = { "highway=primary" }),
+                    @Edge(id = "6000000", coordinates = { @Loc(value = LINK_2),
+                            @Loc(value = HIGHWAY_3) }, tags = { "highway=motorway_link" }),
+                    @Edge(id = "7000000", coordinates = { @Loc(value = LINK_4),
+                            @Loc(value = LINK_3),
                             @Loc(value = LINK_2) }, tags = { "highway=motorway_link" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY2_2), @Loc(value = LINK2_1),
+                    @Edge(id = "8000000", coordinates = { @Loc(value = HIGHWAY2_2),
+                            @Loc(value = LINK2_1),
                             @Loc(value = LINK_2) }, tags = { "highway=motorway_link" }) })
     private Atlas motorwayMotorwayLinkBranchMissingDestinationAtlas;
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheckTestRule.java
@@ -6,11 +6,14 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
 
 /**
  * {@link SignPostCheckTest} data generator
  *
  * @author mkalender
+ * @author bbreithaupt
  */
 public class SignPostCheckTestRule extends CoreTestRule
 {
@@ -24,7 +27,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     private static final String HIGHWAY2_2 = "47.642769, -122.317772";
     private static final String HIGHWAY2_3 = "47.643078, -122.314384";
 
-    static final String LINK_1 = "47.639336, -122.322525";
+    private static final String LINK_1 = "47.639336, -122.322525";
     private static final String LINK_2 = "47.640697, -122.322395";
     private static final String LINK_3 = "47.642033, -122.321556";
     private static final String LINK_4 = "47.642471, -122.319885";
@@ -121,25 +124,6 @@ public class SignPostCheckTestRule extends CoreTestRule
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
             // edges
-            edges = { @Edge(coordinates = { @Loc(value = HIGHWAY_1), @Loc(value = HIGHWAY_2),
-                    @Loc(value = HIGHWAY_3) }, tags = { "highway=primary", "motorroad=yes" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_4),
-                            @Loc(value = HIGHWAY_5) }, tags = { "highway=primary",
-                                    "motorroad=yes" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = LINK_1),
-                            @Loc(value = LINK_2), @Loc(value = LINK_3),
-                            @Loc(value = LINK_4) }, tags = { "highway=primary",
-                                    "diff=treat-me-different" }) })
-    private Atlas motorroadPrimaryMissingJunctionAndDestinationAtlas;
-
-    @TestAtlas(
-            // nodes
-            nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
-                    @Node(coordinates = @Loc(value = HIGHWAY_5)),
-                    @Node(coordinates = @Loc(value = LINK_1)),
-                    @Node(coordinates = @Loc(value = LINK_4)) },
-            // edges
             edges = {
                     @Edge(coordinates = { @Loc(value = HIGHWAY_1), @Loc(value = HIGHWAY_2),
                             @Loc(value = HIGHWAY_3) }, tags = { "highway=trunk" }),
@@ -196,15 +180,17 @@ public class SignPostCheckTestRule extends CoreTestRule
                     @Node(coordinates = @Loc(value = LINK2_1)) },
             // edges
             edges = {
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_1), @Loc(value = HIGHWAY_2),
+                    @Edge(id = "1000000", coordinates = { @Loc(value = HIGHWAY_1),
+                            @Loc(value = HIGHWAY_2),
                             @Loc(value = HIGHWAY_3) }, tags = { "highway=motorway" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_4),
+                    @Edge(id = "2000000", coordinates = { @Loc(value = HIGHWAY_3),
+                            @Loc(value = HIGHWAY_4),
                             @Loc(value = HIGHWAY_5) }, tags = { "highway=motorway" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = LINK_1),
-                            @Loc(value = LINK_2), @Loc(value = LINK_3),
+                    @Edge(id = "3000000", coordinates = { @Loc(value = HIGHWAY_3),
+                            @Loc(value = LINK_1), @Loc(value = LINK_2), @Loc(value = LINK_3),
                             @Loc(value = LINK_4) }, tags = { "highway=motorway_link" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = LINK_1),
-                            @Loc(value = LINK_2),
+                    @Edge(id = "4000000", coordinates = { @Loc(value = HIGHWAY_3),
+                            @Loc(value = LINK_1), @Loc(value = LINK_2),
                             @Loc(value = LINK2_1) }, tags = { "highway=trunk_link" }) })
     private Atlas motorwayMultipleLinksMissingJunctionAndDestinationAtlas;
 
@@ -436,8 +422,10 @@ public class SignPostCheckTestRule extends CoreTestRule
                             @Loc(value = HIGHWAY_3) }, tags = { "highway=motorway" }),
                     @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_2),
                             @Loc(value = HIGHWAY_1) }, tags = { "highway=motorway" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY2_3), @Loc(value = HIGHWAY2_2),
-                            @Loc(value = LINK_4) }, tags = { "highway=primary" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY2_3),
+                            @Loc(value = HIGHWAY2_2) }, tags = { "highway=primary" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY2_2), @Loc(value = LINK_4) }, tags = {
+                            "highway=primary" }),
                     @Edge(coordinates = { @Loc(value = LINK_4), @Loc(value = HIGHWAY2_1) }, tags = {
                             "highway=primary" }),
                     @Edge(coordinates = { @Loc(value = LINK_2), @Loc(value = HIGHWAY_3) }, tags = {
@@ -460,14 +448,16 @@ public class SignPostCheckTestRule extends CoreTestRule
                     @Node(coordinates = @Loc(value = HIGHWAY2_2)),
                     @Node(coordinates = @Loc(value = HIGHWAY2_3)),
                     @Node(coordinates = @Loc(value = LINK_2)),
-                    @Node(coordinates = @Loc(value = LINK_3)),
+                    @Node(id = "11000000", coordinates = @Loc(value = LINK_3)),
                     @Node(coordinates = @Loc(value = LINK_4)),
                     @Node(coordinates = @Loc(value = LINK2_1)) },
             // edges
             edges = {
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_5), @Loc(value = HIGHWAY_4),
+                    @Edge(id = "4000000", coordinates = { @Loc(value = HIGHWAY_5),
+                            @Loc(value = HIGHWAY_4),
                             @Loc(value = HIGHWAY_3) }, tags = { "highway=motorway" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_2),
+                    @Edge(id = "5000000", coordinates = { @Loc(value = HIGHWAY_3),
+                            @Loc(value = HIGHWAY_2),
                             @Loc(value = HIGHWAY_1) }, tags = { "highway=motorway" }),
                     @Edge(id = "1000000", coordinates = { @Loc(value = HIGHWAY2_3),
                             @Loc(value = HIGHWAY2_2),
@@ -479,29 +469,104 @@ public class SignPostCheckTestRule extends CoreTestRule
                             @Loc(value = HIGHWAY2_1) }, tags = { "highway=primary" }),
                     @Edge(id = "-2000000", coordinates = { @Loc(value = HIGHWAY2_1),
                             @Loc(value = LINK_4) }, tags = { "highway=primary" }),
-                    @Edge(coordinates = { @Loc(value = LINK_3), @Loc(value = LINK_2),
+                    @Edge(id = "6000000", coordinates = { @Loc(value = LINK_3),
+                            @Loc(value = LINK_2),
                             @Loc(value = HIGHWAY_3) }, tags = { "highway=motorway_link" }),
                     @Edge(id = "3000000", coordinates = { @Loc(value = LINK_3),
                             @Loc(value = LINK_4) }, tags = { "highway=motorway_link" }),
                     @Edge(id = "-3000000", coordinates = { @Loc(value = LINK_4),
                             @Loc(value = LINK_3) }, tags = { "highway=motorway_link" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_5), @Loc(value = LINK_3) }, tags = {
-                            "highway=motorway_link", "destination=somewhere" }) })
+                    @Edge(id = "7000000", coordinates = { @Loc(value = HIGHWAY_5),
+                            @Loc(value = LINK_3) }, tags = { "highway=motorway_link",
+                                    "destination=somewhere" }), })
     private Atlas motorwayMotorwayLinkTwoWayBranchMissingDestinationAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_2)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_4)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_5), tags = {
+                            "highway=motorway_junction" }),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_1)),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_2)),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_3)),
+                    @Node(coordinates = @Loc(value = LINK_2)),
+                    @Node(id = "11000000", coordinates = @Loc(value = LINK_3)),
+                    @Node(coordinates = @Loc(value = LINK_4)),
+                    @Node(coordinates = @Loc(value = LINK2_1)) },
+            // edges
+            edges = {
+                    @Edge(id = "4000000", coordinates = { @Loc(value = HIGHWAY_5),
+                            @Loc(value = HIGHWAY_4),
+                            @Loc(value = HIGHWAY_3) }, tags = { "highway=motorway" }),
+                    @Edge(id = "5000000", coordinates = { @Loc(value = HIGHWAY_3),
+                            @Loc(value = HIGHWAY_2),
+                            @Loc(value = HIGHWAY_1) }, tags = { "highway=motorway" }),
+                    @Edge(id = "1000000", coordinates = { @Loc(value = HIGHWAY2_3),
+                            @Loc(value = HIGHWAY2_2),
+                            @Loc(value = LINK_4) }, tags = { "highway=primary" }),
+                    @Edge(id = "-1000000", coordinates = { @Loc(value = LINK_4),
+                            @Loc(value = HIGHWAY2_2),
+                            @Loc(value = HIGHWAY2_3) }, tags = { "highway=primary" }),
+                    @Edge(id = "2000000", coordinates = { @Loc(value = LINK_4),
+                            @Loc(value = HIGHWAY2_1) }, tags = { "highway=primary" }),
+                    @Edge(id = "-2000000", coordinates = { @Loc(value = HIGHWAY2_1),
+                            @Loc(value = LINK_4) }, tags = { "highway=primary" }),
+                    @Edge(id = "6000000", coordinates = { @Loc(value = LINK_3),
+                            @Loc(value = LINK_2),
+                            @Loc(value = HIGHWAY_3) }, tags = { "highway=motorway_link" }),
+                    @Edge(id = "3000000", coordinates = { @Loc(value = LINK_3),
+                            @Loc(value = LINK_4) }, tags = { "highway=motorway_link" }),
+                    @Edge(id = "-3000000", coordinates = { @Loc(value = LINK_4),
+                            @Loc(value = LINK_3) }, tags = { "highway=motorway_link" }),
+                    @Edge(id = "7000000", coordinates = { @Loc(value = HIGHWAY_5),
+                            @Loc(value = LINK_3) }, tags = { "highway=motorway_link",
+                                    "destination=somewhere" }), },
+            // relations
+            relations = {
+                    @Relation(members = { @Member(id = "7000000", type = "edge", role = "from"),
+                            @Member(id = "11000000", type = "node", role = "intersection"),
+                            @Member(id = "6000000", type = "edge", role = "to") }, tags = {
+                                    "type=destination_sign", "destination=somewhere" }) })
+    private Atlas motorwayMotorwayLinkTwoWayBranchMissingDestinationRelationAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_2)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_4)),
+                    @Node(coordinates = @Loc(value = LINK_1)),
+                    @Node(coordinates = @Loc(value = LINK_2)) },
+            // edges
+            edges = {
+                    @Edge(id = "1000000", coordinates = { @Loc(value = HIGHWAY_2),
+                            @Loc(value = HIGHWAY_3) }, tags = { "highway=trunk" }),
+                    @Edge(id = "-1000000", coordinates = { @Loc(value = HIGHWAY_3),
+                            @Loc(value = HIGHWAY_2) }, tags = { "highway=trunk" }),
+                    @Edge(id = "2000000", coordinates = { @Loc(value = HIGHWAY_4),
+                            @Loc(value = HIGHWAY_4) }, tags = { "highway=trunk" }),
+                    @Edge(id = "-2000000", coordinates = { @Loc(value = HIGHWAY_4),
+                            @Loc(value = HIGHWAY_3) }, tags = { "highway=trunk" }),
+                    @Edge(id = "3000000", coordinates = { @Loc(value = HIGHWAY_1),
+                            @Loc(value = LINK_1) }, tags = { "highway=trunk" }),
+                    @Edge(id = "-3000000", coordinates = { @Loc(value = LINK_1),
+                            @Loc(value = HIGHWAY_1) }, tags = { "highway=trunk" }),
+                    @Edge(id = "4000000", coordinates = { @Loc(value = LINK_1),
+                            @Loc(value = LINK_2) }, tags = { "highway=trunk" }),
+                    @Edge(id = "-4000000", coordinates = { @Loc(value = LINK_1),
+                            @Loc(value = LINK_2) }, tags = { "highway=trunk" }),
+                    @Edge(id = "5000000", coordinates = { @Loc(value = HIGHWAY_3),
+                            @Loc(value = LINK_1) }, tags = { "highway=trunk_link" }),
+                    @Edge(id = "-5000000", coordinates = { @Loc(value = LINK_1),
+                            @Loc(value = HIGHWAY_3) }, tags = { "highway=trunk_link" }) })
+    private Atlas twoWayTrunksUTurnMissingJunctionAndDestinationAtlas;
 
     public Atlas motorroadPrimaryLinkMissingJunctionAndDestinationAtlas()
     {
         return this.motorroadPrimaryLinkMissingJunctionAndDestinationAtlas;
-    }
-
-    public Atlas motorroadPrimaryMissingJunctionAndDestinationAtlas()
-    {
-        return this.motorroadPrimaryMissingJunctionAndDestinationAtlas;
-    }
-
-    public Atlas motorwayLinkMotorwayMissingJunctionAndDestinationAtlas()
-    {
-        return this.motorwayLinkMotorwayMissingJunctionAndDestinationAtlas;
     }
 
     public Atlas motorwayMotorwayLinkMissingJunctionAndDestinationAtlas()
@@ -547,11 +612,6 @@ public class SignPostCheckTestRule extends CoreTestRule
     public Atlas motorwayTrunkLinkWithDestinationAtlas()
     {
         return this.motorwayTrunkLinkWithDestinationAtlas;
-    }
-
-    public Atlas primaryLinkTrunkMissingJunctionAndDestinationAtlas()
-    {
-        return this.primaryLinkTrunkMissingJunctionAndDestinationAtlas;
     }
 
     public Atlas primaryMotorwayLinkMissingJunctionAndDestinationAtlas()
@@ -602,5 +662,15 @@ public class SignPostCheckTestRule extends CoreTestRule
     public Atlas motorwayMotorwayLinkTwoWayBranchMissingDestinationAtlas()
     {
         return this.motorwayMotorwayLinkTwoWayBranchMissingDestinationAtlas;
+    }
+
+    public Atlas motorwayMotorwayLinkTwoWayBranchMissingDestinationRelationAtlas()
+    {
+        return this.motorwayMotorwayLinkTwoWayBranchMissingDestinationRelationAtlas;
+    }
+
+    public Atlas twoWayTrunksUTurnMissingJunctionAndDestinationAtlas()
+    {
+        return this.twoWayTrunksUTurnMissingJunctionAndDestinationAtlas;
     }
 }


### PR DESCRIPTION
### Description:

This is a major overhaul of the SignPostCheck, to fix a few bugs and make an enhancements.

The major reason for the overhaul was to fix a bug where multiple edges would end up in the same flag, even though they were geographically separate (sometimes by over a kilometer). This occurred because these items were connected to the same motorway or trunk edge, but on different ends, and the edge was used as the starting object for the check. Now the starting object is the ramp edges themselves, so the starting object is always the only item that is flagged. As part of this change, the configurables `ramp.max.edges` and `arterial.minimum` were removed. The logic these supported is no longer in the check. 

Previously these three items, that are about 2km apart, were part of the same flag. Now they would all be separate flags.
![Screen Shot 2019-04-23 at 9 21 01 AM](https://user-images.githubusercontent.com/24948563/56598383-3f74ac00-65a9-11e9-9ba8-68fb35cb1d21.png)

The second bug that was fixed was that this check assumed it was always working with one way roads. This meant that edges/ways would sometimes be flagged multiple times. The check now accounts for reverse edges and way sectioning.

The final bug fix was to look for [destination relations](https://wiki.openstreetmap.org/wiki/Relation:destination_sign), instead of just destination tags, and to add the tags `destination:backward` and `destination:forwards` to the `destination_tag.filter` configurable. This fixed a few false positive flags where items were flagged for not having destination tags.

The one enhancement was to add an optional part of the check for branching ramps. This is to catch where a ramp has a single entrance, but multiple exits. In these cases, when the ramp branches towards the different exits there usually should be destination tags. However, some locations may not use road signs for these instances. So, this feature is controlled by a configurable, and can be turned on or off as needed. 

An example of a ramp branch with a destination tag:
![Screen Shot 2019-04-23 at 9 33 08 AM](https://user-images.githubusercontent.com/24948563/56599154-dc841480-65aa-11e9-9b8d-a0649efe5798.png)


### Potential Impact:

None

### Unit Test Approach:

Updated the unit test configurations to match the new design of the check. Also updated existing unit tests, and created a new one to test the new branching logic. 

### Test Results:

Running currently, will update soon. 

