### PR TITLE
Flag Statistics Command Parallel Bug Fix

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/commands/FlagStatisticsSubCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/commands/FlagStatisticsSubCommand.java
@@ -258,7 +258,7 @@ public class FlagStatisticsSubCommand extends AbstractAtlasShellToolsCommand
                                         file.getName(), exception.getMessage()));
                     }
                     return countryCheckMap;
-                }).reduce(this::mergeMaps).orElse(new HashMap<>());
+                }).collect(HashMap::new, this::mergeMaps, this::mergeMaps);
     }
 
     /**
@@ -272,20 +272,20 @@ public class FlagStatisticsSubCommand extends AbstractAtlasShellToolsCommand
      *            {@link String}
      * @return a merged 2d country checks {@link HashMap}
      */
-    private Map<String, Map<String, Counter>> mergeMaps(final Map<String, Map<String, Counter>> put,
-            final Map<String, Map<String, Counter>> place)
+    private Map<String, Map<String, Counter>> mergeMaps(
+            final Map<String, Map<String, Counter>> place,
+            final Map<String, Map<String, Counter>> put)
     {
-        final Map<String, Map<String, Counter>> mergedMap = new HashMap<>(place);
         put.forEach((country, checks) ->
         {
-            mergedMap.putIfAbsent(country, new HashMap<>());
+            place.putIfAbsent(country, new HashMap<>());
             checks.forEach((check, counter) ->
             {
-                mergedMap.get(country).putIfAbsent(check, new Counter());
-                mergedMap.get(country).get(check).add(counter.getValue());
+                place.get(country).putIfAbsent(check, new Counter());
+                place.get(country).get(check).add(counter.getValue());
             });
         });
-        return mergedMap;
+        return place;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/commands/FlagStatisticsSubCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/commands/FlagStatisticsSubCommand.java
@@ -13,11 +13,11 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
@@ -208,7 +208,8 @@ public class FlagStatisticsSubCommand extends AbstractAtlasShellToolsCommand
      */
     private Map<String, Map<String, Counter>> getCountryCheckCounts(final String path)
     {
-        final Map<String, Map<String, Counter>> countryCheckMap = new ConcurrentHashMap<>();
+        final Map<String, Map<String, Counter>> countryCheckMap = Collections
+                .synchronizedMap(new HashMap<>());
         logger.info("Reading files from: {}", path);
 
         // Check all files in the folder and all sub-folders
@@ -224,7 +225,8 @@ public class FlagStatisticsSubCommand extends AbstractAtlasShellToolsCommand
                     // Get the parent folder name and assume it is a county code
                     final String country = FilenameUtils.getName(file.getParent());
                     // Add the country to the map
-                    countryCheckMap.putIfAbsent(country, new ConcurrentHashMap<>());
+                    countryCheckMap.putIfAbsent(country,
+                            Collections.synchronizedMap(new HashMap<>()));
 
                     // Read the log file
                     try (InputStreamReader inputStreamReader = file.isGzipped()

--- a/src/main/java/org/openstreetmap/atlas/checks/commands/FlagStatisticsSubCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/commands/FlagStatisticsSubCommand.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -208,25 +207,24 @@ public class FlagStatisticsSubCommand extends AbstractAtlasShellToolsCommand
      */
     private Map<String, Map<String, Counter>> getCountryCheckCounts(final String path)
     {
-        final Map<String, Map<String, Counter>> countryCheckMap = Collections
-                .synchronizedMap(new HashMap<>());
+
         logger.info("Reading files from: {}", path);
 
         // Check all files in the folder and all sub-folders
-        new File(path).listFilesRecursively().parallelStream()
+        return new File(path).listFilesRecursively().parallelStream()
                 // Filter the files to only include log files, either gzipped or uncompressed
                 .filter(file -> FilenameUtils
                         .getExtension(file.isGzipped() ? FilenameUtils.getBaseName(file.getName())
                                 : file.getName())
                         .equalsIgnoreCase("log"))
-                .forEach(file ->
+                .map(file ->
                 {
+                    final Map<String, Map<String, Counter>> countryCheckMap = new HashMap<>();
                     logger.info("Reading: {}", file.getName());
                     // Get the parent folder name and assume it is a county code
                     final String country = FilenameUtils.getName(file.getParent());
                     // Add the country to the map
-                    countryCheckMap.putIfAbsent(country,
-                            Collections.synchronizedMap(new HashMap<>()));
+                    countryCheckMap.putIfAbsent(country, new HashMap<>());
 
                     // Read the log file
                     try (InputStreamReader inputStreamReader = file.isGzipped()
@@ -259,9 +257,35 @@ public class FlagStatisticsSubCommand extends AbstractAtlasShellToolsCommand
                                 String.format("Exception thrown while reading file %s: %s",
                                         file.getName(), exception.getMessage()));
                     }
-                });
+                    return countryCheckMap;
+                }).reduce(this::mergeMaps).orElse(new HashMap<>());
+    }
 
-        return countryCheckMap;
+    /**
+     * Merges one 2d country checks {@link HashMap} into another.
+     *
+     * @param put
+     *            a 2D {@link Map} of flag {@link Counter}s per check {@link String} per country *
+     *            {@link String}
+     * @param place
+     *            a 2D {@link Map} of flag {@link Counter}s per check {@link String} per country *
+     *            {@link String}
+     * @return a merged 2d country checks {@link HashMap}
+     */
+    private Map<String, Map<String, Counter>> mergeMaps(final Map<String, Map<String, Counter>> put,
+            final Map<String, Map<String, Counter>> place)
+    {
+        final Map<String, Map<String, Counter>> mergedMap = new HashMap<>(place);
+        put.forEach((country, checks) ->
+        {
+            mergedMap.putIfAbsent(country, new HashMap<>());
+            checks.forEach((check, counter) ->
+            {
+                mergedMap.get(country).putIfAbsent(check, new Counter());
+                mergedMap.get(country).get(check).add(counter.getValue());
+            });
+        });
+        return mergedMap;
     }
 
     /**


### PR DESCRIPTION
### Description:

There is a bug in the Flag Statistics command caused by the parallelStream file reader writing to a single hash map. This was causing flag counts to be lower than expected. This fixes the bug by mapping each file to its own hash map, and using a reducer to combine all the maps. 

### Potential Impact:
NA

### Unit Test Approach:
No change.

### Test Results:
Tested against a data set generated using a non-parallel stream. Results for the old parallel single map system differed from the non-parallel. The new reducer system created the same results as the non-parallel run. 

