### PR TITLE
Flag Statistics: All Outputs By Default

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/commands/FlagStatisticsSubCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/commands/FlagStatisticsSubCommand.java
@@ -94,9 +94,14 @@ public class FlagStatisticsSubCommand extends AbstractAtlasShellToolsCommand
         final String outputFolder = this.optionAndArgumentDelegate.getOptionArgument(OUTPUT_OPTION)
                 .get();
         // Get the output types
-        final List<String> outputTypes = Arrays.asList(StringUtils
-                .split(this.optionAndArgumentDelegate.getOptionArgument(OUTPUT_TYPES_OPTION)
-                        .orElse(OutputTypes.RUN_SUMMARY.toString()).toUpperCase(), ','));
+        final List<String> outputTypes = Arrays
+                .asList(StringUtils
+                        .split(this.optionAndArgumentDelegate.getOptionArgument(OUTPUT_TYPES_OPTION)
+                                .orElse(String
+                                        .join(COMMA,
+                                                Arrays.stream(OutputTypes.values()).map(Enum::name)
+                                                        .collect(Collectors.toSet())))
+                                .toUpperCase(), ','));
 
         try
         {
@@ -192,7 +197,7 @@ public class FlagStatisticsSubCommand extends AbstractAtlasShellToolsCommand
         this.registerOptionWithRequiredArgument(OUTPUT_OPTION, 'o',
                 "A folder to output results to.", OptionOptionality.REQUIRED, OUTPUT_OPTION);
         this.registerOptionWithRequiredArgument(OUTPUT_TYPES_OPTION, 't',
-                "A comma separated list of outputs to generate: full,totals,counts",
+                "A comma separated list of outputs to generate: run_summary,check_summary,check_by_country",
                 OptionOptionality.OPTIONAL, OUTPUT_TYPES_OPTION);
         super.registerOptionsAndArguments();
     }


### PR DESCRIPTION
### Description:

This changes the default output types for the FlagStatisticsSubCommand to be all output types. 

### Potential Impact:
Anything that used the default will see an increase in output files. 

### Unit Test Approach:

No new unit tests.

### Test Results:

Tested with and without the output-types argument. The results were as expected. 

