### PR TITLE
MalformedRoundaboutCheck Use ComplexRoundabout

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
@@ -5,19 +5,18 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Stream;
+import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
-import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Route;
-import org.openstreetmap.atlas.geography.atlas.walker.SimpleEdgeWalker;
+import org.openstreetmap.atlas.geography.atlas.items.complex.ComplexEntity;
+import org.openstreetmap.atlas.geography.atlas.items.complex.roundabout.ComplexRoundabout;
 import org.openstreetmap.atlas.tags.BridgeTag;
 import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.ISOCountryTag;
@@ -36,25 +35,10 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  * @author bbreithaupt
  */
 
-public class MalformedRoundaboutCheck extends BaseCheck
+public class MalformedRoundaboutCheck extends BaseCheck<Long>
 {
-    /**
-     * An enum of RoundaboutDirections
-     */
-    public enum RoundaboutDirection
-    {
-        CLOCKWISE,
-        COUNTERCLOCKWISE,
-        // Handles the case where we were unable to get any information about the roundabout's
-        // Direction.
-        UNKNOWN
-    }
-
     private static final long serialVersionUID = -3018101860747289836L;
     private static final String BASIC_INSTRUCTION = "This roundabout is malformed.";
-    private static final String WRONG_WAY_INSTRUCTIONS = "This roundabout is going the"
-            + " wrong direction, or has been improperly tagged as a roundabout.";
-    private static final String INCOMPLETE_ROUTE_INSTRUCTIONS = "This roundabout does not form a single, one-way, complete, car navigable route.";
     private static final String ENCLOSED_ROADS_INSTRUCTIONS = "This roundabout has car navigable ways inside it.";
     private static final List<String> LEFT_DRIVING_COUNTRIES_DEFAULT = Arrays.asList("AIA", "ATG",
             "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN", "BWA", "CCK", "COK", "CXR", "CYM",
@@ -64,107 +48,15 @@ public class MalformedRoundaboutCheck extends BaseCheck
             "PAK", "PCN", "PNG", "SGP", "SGS", "SHN", "SLB", "SUR", "SWZ", "SYC", "TCA", "THA",
             "TKL", "TLS", "TON", "TTO", "TUV", "TZA", "UGA", "VCT", "VGB", "VIR", "WSM", "ZAF",
             "ZMB", "ZWE");
-    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(WRONG_WAY_INSTRUCTIONS,
-            INCOMPLETE_ROUTE_INSTRUCTIONS, ENCLOSED_ROADS_INSTRUCTIONS, BASIC_INSTRUCTION);
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
+            .asList(ENCLOSED_ROADS_INSTRUCTIONS, BASIC_INSTRUCTION);
     private final List<String> leftDrivingCountries;
-
-    /**
-     * This method returns a RoundaboutDirection enum which indicates direction of the flow of
-     * traffic based on the cross product of two adjacent edges. This method leverages the
-     * right-hand rule as it relates to the directionality of two vectors.
-     *
-     * @see "https://en.wikipedia.org/wiki/Right-hand_rule"
-     * @param roundaboutEdges
-     *            A list of Edges in a roundabout
-     * @return CLOCKWISE or COUNTERCLOCKWISE if the majority of the edges have positive or negative
-     *         cross products respectively, and UNKNOWN if all edge cross products are 0 or if the
-     *         roundabout's geometry is malformed
-     */
-    private static RoundaboutDirection findRoundaboutDirection(final Route roundaboutEdges)
-    {
-        int clockwiseCount = 0;
-        int counterClockwiseCount = 0;
-
-        for (int idx = 0; idx < roundaboutEdges.size(); idx++)
-        {
-            // Get the Edges to use in the cross product
-            final Edge edge1 = roundaboutEdges.get(idx);
-            // We mod the roundabout edges here so that we can get the last pair of edges in the
-            // Roundabout correctly
-            final Edge edge2 = roundaboutEdges.get((idx + 1) % roundaboutEdges.size());
-            // Get the cross product and then the direction of the roundabout
-            final double crossProduct = getCrossProduct(edge1, edge2);
-            final RoundaboutDirection direction = crossProduct < 0
-                    ? RoundaboutDirection.COUNTERCLOCKWISE
-                    : (crossProduct > 0) ? RoundaboutDirection.CLOCKWISE
-                            : RoundaboutDirection.UNKNOWN;
-
-            // If the direction is UNKNOWN then we continue to the next iteration because we do not
-            // Have any new information about the roundabout's direction
-            if (direction.equals(RoundaboutDirection.UNKNOWN))
-            {
-                continue;
-            }
-            if (direction.equals(RoundaboutDirection.CLOCKWISE))
-            {
-                clockwiseCount += 1;
-            }
-            if (direction.equals(RoundaboutDirection.COUNTERCLOCKWISE))
-            {
-                counterClockwiseCount += 1;
-            }
-        }
-        // Return the Enum for whatever has the highest count
-        if (clockwiseCount > counterClockwiseCount)
-        {
-            return RoundaboutDirection.CLOCKWISE;
-        }
-        else if (clockwiseCount < counterClockwiseCount)
-        {
-            return RoundaboutDirection.COUNTERCLOCKWISE;
-        }
-        else
-        {
-            return RoundaboutDirection.UNKNOWN;
-        }
-    }
-
-    /**
-     * This method returns the cross product between two adjacent edges.
-     *
-     * @see "https://en.wikipedia.org/wiki/Cross_product"
-     * @param edge1
-     *            An Edge entity in the roundabout
-     * @param edge2
-     *            An Edge entity in the roundabout adjacent to edge1
-     * @return A double corresponding to the cross product between two edges
-     */
-    private static Double getCrossProduct(final Edge edge1, final Edge edge2)
-    {
-        // Get the nodes' latitudes and longitudes to use in deriving the vectors
-        final double node1Y = edge1.start().getLocation().getLatitude().asDegrees();
-        final double node1X = edge1.start().getLocation().getLongitude().asDegrees();
-        final double node2Y = edge1.end().getLocation().getLatitude().asDegrees();
-        final double node2X = edge1.end().getLocation().getLongitude().asDegrees();
-        final double node3Y = edge2.end().getLocation().getLatitude().asDegrees();
-        final double node3X = edge2.end().getLocation().getLongitude().asDegrees();
-
-        // Get the vectors from node 2 to 1, and node 2 to 3
-        final double vector1X = node2X - node1X;
-        final double vector1Y = node2Y - node1Y;
-        final double vector2X = node2X - node3X;
-        final double vector2Y = node2Y - node3Y;
-
-        // The cross product tells us the direction of the orthogonal vector, which is
-        // Directly related to the direction of rotation/traffic
-        return (vector1X * vector2Y) - (vector1Y * vector2X);
-    }
 
     public MalformedRoundaboutCheck(final Configuration configuration)
     {
         super(configuration);
-        this.leftDrivingCountries = (List<String>) configurationValue(configuration,
-                "traffic.countries.left", LEFT_DRIVING_COUNTRIES_DEFAULT);
+        this.leftDrivingCountries = configurationValue(configuration, "traffic.countries.left",
+                LEFT_DRIVING_COUNTRIES_DEFAULT);
     }
 
     @Override
@@ -194,64 +86,38 @@ public class MalformedRoundaboutCheck extends BaseCheck
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
-        final Edge edge = (Edge) object;
-        final String isoCountryCode = edge.tag(ISOCountryTag.KEY).toUpperCase();
         final Set<String> instructions = new HashSet<>();
-
-        // Get all edges in the roundabout
-        final Set<Edge> roundaboutEdgeSet = new SimpleEdgeWalker(edge, this.isRoundaboutEdge())
-                .collectEdges();
+        // Create a ComplexRoundabout based on object
+        final ComplexRoundabout complexRoundabout = new ComplexRoundabout((Edge) object,
+                this.leftDrivingCountries);
+        // If the ComplexRoundbaout is invalid add the reasons why to the instructions, so that it
+        // will be flagged
+        if (!complexRoundabout.isValid())
+        {
+            instructions.addAll(complexRoundabout.getAllInvalidations().stream()
+                    .map(ComplexEntity.ComplexEntityError::getReason).collect(Collectors.toSet()));
+        }
+        // Get the roundabout Edges
+        final Set<Edge> roundaboutEdgeSet = complexRoundabout.getRoundaboutEdgeSet();
+        // Get the roundabout Route
+        final Route roundaboutEdges = complexRoundabout.getRoundaboutRoute();
+        // Mark that the Edges have been processed
         roundaboutEdgeSet
                 .forEach(roundaboutEdge -> this.markAsFlagged(roundaboutEdge.getIdentifier()));
-        final Route roundaboutEdges;
-
-        // Try to build a Route from the edges
-        try
-        {
-            roundaboutEdges = Route.fromNonArrangedEdgeSet(roundaboutEdgeSet, false);
-        }
-        // If a Route cannot be formed, flag the edges as an incomplete roundabout.
-        catch (final CoreException badRoundabout)
-        {
-            return Optional.of(this.createFlag(roundaboutEdgeSet, this.getLocalizedInstruction(1)));
-        }
-
-        // Flag if any of the edges are not car navigable or master Edges, or the route does not
-        // form a closed loop.
-        if (roundaboutEdgeSet.stream()
-                .anyMatch(roundaboutEdge -> !HighwayTag.isCarNavigableHighway(roundaboutEdge)
-                        || !roundaboutEdge.isMasterEdge())
-                || !roundaboutEdges.start().inEdges().contains(roundaboutEdges.end()))
-        {
-            instructions.add(this.getLocalizedInstruction(1));
-        }
-
-        // Get the direction of the roundabout
-        final RoundaboutDirection direction = findRoundaboutDirection(roundaboutEdges);
-
-        // Determine if the roundabout is in a left or right driving country
-        final boolean isLeftDriving = this.leftDrivingCountries.contains(isoCountryCode);
-
-        // If the roundabout traffic is clockwise in a right-driving country, or
-        // If the roundabout traffic is counterclockwise in a left-driving country
-        if (direction.equals(RoundaboutDirection.CLOCKWISE) && !isLeftDriving
-                || direction.equals(RoundaboutDirection.COUNTERCLOCKWISE) && isLeftDriving)
-        {
-            instructions.add(this.getLocalizedInstruction(0));
-        }
 
         // If there are car navigable edges inside the roundabout flag it, as it is probably
         // malformed or a throughabout
-        if (roundaboutEdgeSet.stream().noneMatch(this::ignoreBridgeTunnelCrossings)
+        if (!roundaboutEdgeSet.isEmpty() && roundaboutEdges != null
+                && roundaboutEdgeSet.stream().noneMatch(this::ignoreBridgeTunnelCrossings)
                 && this.roundaboutEnclosesRoads(roundaboutEdges))
         {
-            instructions.add(this.getLocalizedInstruction(2));
+            instructions.add(this.getLocalizedInstruction(0));
         }
 
         if (!instructions.isEmpty())
         {
             final CheckFlag flag = this.createFlag(roundaboutEdgeSet,
-                    this.getLocalizedInstruction(3));
+                    this.getLocalizedInstruction(1));
             instructions.forEach(flag::addInstruction);
             return Optional.of(flag);
         }
@@ -308,19 +174,6 @@ public class MalformedRoundaboutCheck extends BaseCheck
     {
         return Validators.isOfType(object, HighwayTag.class, HighwayTag.CYCLEWAY,
                 HighwayTag.PEDESTRIAN, HighwayTag.FOOTWAY);
-    }
-
-    /**
-     * Function for {@link SimpleEdgeWalker} that gathers connected edges that are part of a
-     * roundabout.
-     *
-     * @return {@link Function} for {@link SimpleEdgeWalker}
-     */
-    private Function<Edge, Stream<Edge>> isRoundaboutEdge()
-    {
-        return edge -> edge.connectedEdges().stream()
-                .filter(connected -> JunctionTag.isRoundabout(connected)
-                        && !this.isExcludedHighway(connected));
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
@@ -144,6 +144,15 @@ public class MalformedRoundaboutCheckTest
     }
 
     @Test
+    public void testCounterClockwiseRoundaboutRightDrivingMadeLeftAtlas()
+    {
+        this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingAtlas(),
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"traffic.countries.left\":[\"USA\"]}}")));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
     public void testMultiDirectionalRoundaboutAtlas()
     {
         this.verifier.actual(this.setup.multiDirectionalRoundaboutAtlas(),


### PR DESCRIPTION
### Description:

With the addition of the CompleRoundabout class to Atlas, much of the logic in MalformedRoundaboutCheck is redundant. This removes the redundant logic and replaces it with calls to ComplexRoundabout.

### Potential Impact:
There should not be any downstream impact. 

### Unit Test Approach:

Added one unit test for the left driving countries configurable.

### Test Results:

Tested the check on 5 countries. The flags were the same before and after the changes. 

