### PR TITLE
Simple Flag Reader

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/utility/FlagReader.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/FlagReader.java
@@ -1,0 +1,75 @@
+package org.openstreetmap.atlas.checks.utility;
+
+import static org.openstreetmap.atlas.checks.utility.GeoJsonCheckFlag.GENERATOR_KEY;
+import static org.openstreetmap.atlas.checks.utility.GeoJsonCheckFlag.IDENTIFIER_KEY;
+import static org.openstreetmap.atlas.checks.utility.GeoJsonCheckFlag.INSTRUCTIONS_KEY;
+import static org.openstreetmap.atlas.checks.utility.GeoJsonCheckFlag.TIMESTAMP_KEY;
+import static org.openstreetmap.atlas.geography.geojson.GeoJsonConstants.FEATURES;
+import static org.openstreetmap.atlas.geography.geojson.GeoJsonConstants.PROPERTIES;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * Read {@link CheckFlag}s serialized as geojson feature collections and convert them to
+ * {@link GeoJsonCheckFlag}s.
+ *
+ * @author bbreithaupt
+ */
+public final class FlagReader
+{
+    /**
+     * {@link JsonDeserializer} for {@link GeoJsonCheckFlag}s
+     */
+    public static class GeoJsonCheckFlagDeserializer implements JsonDeserializer<GeoJsonCheckFlag>
+    {
+        @Override
+        public GeoJsonCheckFlag deserialize(final JsonElement json, final Type typeOfT,
+                final JsonDeserializationContext context)
+        {
+            final JsonObject properties = json.getAsJsonObject().get(PROPERTIES).getAsJsonObject();
+            final String identifier = properties.get(IDENTIFIER_KEY).getAsString();
+            final String instructions = properties.get(INSTRUCTIONS_KEY).getAsString();
+            final String generator = properties.get(GENERATOR_KEY).getAsString();
+            final String timestamp = properties.get(TIMESTAMP_KEY).getAsString();
+            final List<JsonObject> features = Iterables
+                    .asList(json.getAsJsonObject().get(FEATURES).getAsJsonArray()).stream()
+                    .map(JsonElement::getAsJsonObject).collect(Collectors.toList());
+
+            return new GeoJsonCheckFlag(identifier, instructions, generator, timestamp, features);
+        }
+    }
+
+    // GsonBuilder with a GeoJsonCheckFlag adapter
+    private static final Gson GSON = new GsonBuilder()
+            .registerTypeAdapter(GeoJsonCheckFlag.class, new GeoJsonCheckFlagDeserializer())
+            .create();
+
+    /**
+     * Convert a single {@link String} {@link CheckFlag} feature collection to a
+     * {@link GeoJsonCheckFlag}.
+     *
+     * @param string
+     *            {@link CheckFlag}s serialized as geojson feature collection {@link String}
+     * @return a {@link GeoJsonCheckFlag} version of the {@link CheckFlag}
+     */
+    public static GeoJsonCheckFlag readFlagFromString(final String string)
+    {
+        return GSON.fromJson(string, GeoJsonCheckFlag.class);
+    }
+
+    private FlagReader()
+    {
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/GeoJsonCheckFlag.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/GeoJsonCheckFlag.java
@@ -1,0 +1,116 @@
+package org.openstreetmap.atlas.checks.utility;
+
+import static org.openstreetmap.atlas.geography.geojson.GeoJsonConstants.FEATURES;
+import static org.openstreetmap.atlas.geography.geojson.GeoJsonConstants.PROPERTIES;
+import static org.openstreetmap.atlas.geography.geojson.GeoJsonConstants.TYPE;
+
+import java.util.List;
+
+import org.openstreetmap.atlas.checks.event.CheckFlagEvent;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.geojson.GeoJsonType;
+import org.openstreetmap.atlas.utilities.collections.Maps;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+/**
+ * A simplified representation of a {@link CheckFlag}. Flag features are stored as
+ * geo{@link JsonObject}s.
+ *
+ * @author bbreithaupt
+ */
+public class GeoJsonCheckFlag
+{
+    protected static final String IDENTIFIER_KEY = "id";
+    protected static final String INSTRUCTIONS_KEY = "instructions";
+    protected static final String GENERATOR_KEY = "generator";
+    protected static final String TIMESTAMP_KEY = "timestamp";
+
+    private static Gson GSON = new Gson();
+
+    private String identifier;
+    private String instructions;
+    private String checkName;
+    private String timestamp;
+    private List<JsonObject> features;
+
+    public GeoJsonCheckFlag(final String identifier, final String instructions,
+            final String checkName, final String timestamp, final List<JsonObject> features)
+    {
+        this.identifier = identifier;
+        this.instructions = instructions;
+        this.checkName = checkName;
+        this.timestamp = timestamp;
+        this.features = features;
+    }
+
+    public String getCheckName()
+    {
+        return this.checkName;
+    }
+
+    public List<JsonObject> getFeatures()
+    {
+        return this.features;
+    }
+
+    public String getIdentifier()
+    {
+        return this.identifier;
+    }
+
+    public String getInstructions()
+    {
+        return this.instructions;
+    }
+
+    public String getTimestamp()
+    {
+        return this.timestamp;
+    }
+
+    public void setCheckName(final String checkName)
+    {
+        this.checkName = checkName;
+    }
+
+    public void setFeatures(final List<JsonObject> features)
+    {
+        this.features = features;
+    }
+
+    public void setIdentifier(final String identifier)
+    {
+        this.identifier = identifier;
+    }
+
+    public void setInstructions(final String instructions)
+    {
+        this.instructions = instructions;
+    }
+
+    public void setTimestamp(final String timestamp)
+    {
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * Serializes the flag to be the same as the output of {@link CheckFlagEvent}'s
+     * {@code .toString()}.
+     *
+     * @return a {@link String} serialization of the flag
+     */
+    public String toString()
+    {
+        final JsonObject featureCollection = new JsonObject();
+        featureCollection.addProperty(TYPE, GeoJsonType.FEATURE_COLLECTION.getTypeString());
+        featureCollection.add(FEATURES, GSON.toJsonTree(this.features));
+        featureCollection.add(PROPERTIES,
+                GSON.toJsonTree(Maps.hashMap(IDENTIFIER_KEY, this.identifier, INSTRUCTIONS_KEY,
+                        this.instructions, GENERATOR_KEY, this.checkName, TIMESTAMP_KEY,
+                        this.timestamp)));
+
+        return featureCollection.toString();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/FlagReaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/FlagReaderTest.java
@@ -1,0 +1,54 @@
+package org.openstreetmap.atlas.checks.utility;
+
+import static org.openstreetmap.atlas.checks.utility.FlagReaderTestRule.CHECK_1;
+import static org.openstreetmap.atlas.checks.utility.FlagReaderTestRule.CHECK_2;
+import static org.openstreetmap.atlas.checks.utility.FlagReaderTestRule.IDENTIFIER_ONE;
+import static org.openstreetmap.atlas.checks.utility.FlagReaderTestRule.IDENTIFIER_TWO;
+import static org.openstreetmap.atlas.checks.utility.FlagReaderTestRule.TEST_INSTRUCTION;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Unit tests from {@link FlagReader} and {@link GeoJsonCheckFlag}.
+ *
+ * @author bbreithaupt
+ */
+public class FlagReaderTest
+{
+
+    @Rule
+    public final FlagReaderTestRule setup = new FlagReaderTestRule();
+
+    @Test
+    public void oneFeatureTest()
+    {
+        final GeoJsonCheckFlag geoJsonCheckFlag = FlagReader
+                .readFlagFromString(this.setup.getOneNodeCheckFlagEvent().toString());
+        Assert.assertEquals(IDENTIFIER_ONE, geoJsonCheckFlag.getIdentifier());
+        Assert.assertTrue(geoJsonCheckFlag.getInstructions().contains(TEST_INSTRUCTION));
+        Assert.assertEquals(CHECK_1, geoJsonCheckFlag.getCheckName());
+        Assert.assertEquals(1, geoJsonCheckFlag.getFeatures().size());
+    }
+
+    @Test
+    public void reserializeTest()
+    {
+        final String flagString = this.setup.getTwoNodeCheckFlagEvent().toString();
+        final GeoJsonCheckFlag geoJsonCheckFlag = FlagReader.readFlagFromString(flagString);
+        Assert.assertEquals(flagString.length(), geoJsonCheckFlag.toString().length());
+    }
+
+    @Test
+    public void twoFeaturesTest()
+    {
+        final GeoJsonCheckFlag geoJsonCheckFlag = FlagReader
+                .readFlagFromString(this.setup.getTwoNodeCheckFlagEvent().toString());
+        Assert.assertEquals(IDENTIFIER_ONE.concat(IDENTIFIER_TWO),
+                geoJsonCheckFlag.getIdentifier());
+        Assert.assertTrue(geoJsonCheckFlag.getInstructions().contains(TEST_INSTRUCTION));
+        Assert.assertEquals(CHECK_2, geoJsonCheckFlag.getCheckName());
+        Assert.assertEquals(2, geoJsonCheckFlag.getFeatures().size());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/FlagReaderTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/FlagReaderTestRule.java
@@ -26,7 +26,7 @@ public class FlagReaderTestRule extends CoreTestRule
     private static final String TEST_2 = "42.8168030,10.3320820";
 
     @TestAtlas(nodes = { @Node(id = IDENTIFIER_ONE, coordinates = @Loc(value = TEST_1)),
-            @Node(id = IDENTIFIER_TWO, coordinates = @Loc(value = TEST_1)) })
+            @Node(id = IDENTIFIER_TWO, coordinates = @Loc(value = TEST_2)) })
     private Atlas atlas;
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/FlagReaderTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/FlagReaderTestRule.java
@@ -1,0 +1,63 @@
+package org.openstreetmap.atlas.checks.utility;
+
+import org.openstreetmap.atlas.checks.event.CheckFlagEvent;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * Unit test rule for {@link FlagReaderTest}.
+ *
+ * @author bbreithaupt
+ */
+public class FlagReaderTestRule extends CoreTestRule
+{
+    static final String TEST_INSTRUCTION = "This is a test flag.";
+    static final String IDENTIFIER_ONE = "1000000";
+    static final String IDENTIFIER_TWO = "2000000";
+    static final String CHECK_1 = "Check1";
+    static final String CHECK_2 = "Check2";
+
+    private static final String TEST_1 = "42.7856273,10.2804429";
+    private static final String TEST_2 = "42.8168030,10.3320820";
+
+    @TestAtlas(nodes = { @Node(id = IDENTIFIER_ONE, coordinates = @Loc(value = TEST_1)),
+            @Node(id = IDENTIFIER_TWO, coordinates = @Loc(value = TEST_1)) })
+    private Atlas atlas;
+
+    /**
+     * Generate a simple {@link CheckFlagEvent}, that has one node and uses a test instruction.
+     *
+     * @return a {@link CheckFlagEvent}
+     */
+    public CheckFlagEvent getOneNodeCheckFlagEvent()
+    {
+        final AtlasObject node = this.atlas.node(1000000L);
+        final CheckFlag flag = new CheckFlag(String.valueOf(node.getIdentifier()));
+        flag.addObject(node);
+        flag.addInstruction(TEST_INSTRUCTION);
+
+        return new CheckFlagEvent(CHECK_1, flag);
+    }
+
+    /**
+     * Generate a simple {@link CheckFlagEvent}, that has two nodes and uses a test instruction.
+     *
+     * @return a {@link CheckFlagEvent}
+     */
+    public CheckFlagEvent getTwoNodeCheckFlagEvent()
+    {
+        final AtlasObject nodeOne = this.atlas.node(1000000L);
+        final AtlasObject nodeTwo = this.atlas.node(2000000L);
+        final CheckFlag flag = new CheckFlag(IDENTIFIER_ONE.concat(IDENTIFIER_TWO));
+        flag.addObject(nodeOne);
+        flag.addObject(nodeTwo);
+        flag.addInstruction(TEST_INSTRUCTION);
+
+        return new CheckFlagEvent(CHECK_2, flag);
+    }
+}


### PR DESCRIPTION
### Description:

This adds a class for reading serialized check flags back into memory. It does not de-serialize a flag back into a CheckFlag, but instead stores it as a GeoJsonCheckFlag. The GeoJsonCheckFlag representation of a CheckFlag exposes a flags meta data while keeping the features in geojson format. This is useful for performing simple manipulations or counts on flags (as in the MapRouletteUploadCommand and FlagStatisticsSubCommand).

### Potential Impact:

No impacts, as everything is new.

### Unit Test Approach:

Unit tests use flags generated on the fly to check the conversion from serialized CheckFlags to GeoJsonCheckFlags and back again.  

### Test Results:

None

